### PR TITLE
Modify the check in spenders

### DIFF
--- a/src/SpenderAaveV2Delegation.sol
+++ b/src/SpenderAaveV2Delegation.sol
@@ -24,6 +24,7 @@ contract SpenderAaveV2Delegation is ISpenderAaveV2Delegation {
     /// @notice Router asks to borrow tokens using the user's delegation
     /// @dev Router must guarantee that the public user is msg.sender who called Router.
     function borrow(address asset, uint256 amount, uint256 interestRateMode) external {
+        if (msg.sender != router) revert InvalidRouter();
         address user = IRouter(router).user();
 
         address pool = IAaveV2Provider(aaveV2Provider).getLendingPool();

--- a/src/SpenderERC20Approval.sol
+++ b/src/SpenderERC20Approval.sol
@@ -18,12 +18,14 @@ contract SpenderERC20Approval is ISpenderERC20Approval {
     /// @notice Router asks to transfer tokens from the user
     /// @dev Router must guarantee that the public user is msg.sender who called Router.
     function pullToken(address token, uint256 amount) external {
+        if (msg.sender != router) revert InvalidRouter();
         address user = IRouter(router).user();
 
         _pull(token, amount, user);
     }
 
     function pullTokens(address[] calldata tokens, uint256[] calldata amounts) external {
+        if (msg.sender != router) revert InvalidRouter();
         address user = IRouter(router).user();
 
         uint256 tokensLength = tokens.length;

--- a/src/interfaces/ISpenderAaveV2Delegation.sol
+++ b/src/interfaces/ISpenderAaveV2Delegation.sol
@@ -2,5 +2,7 @@
 pragma solidity ^0.8.0;
 
 interface ISpenderAaveV2Delegation {
+    error InvalidRouter();
+
     function borrow(address asset, uint256 amount, uint256 interestRateMode) external;
 }

--- a/src/interfaces/ISpenderERC20Approval.sol
+++ b/src/interfaces/ISpenderERC20Approval.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 interface ISpenderERC20Approval {
+    error InvalidRouter();
     error LengthMismatch();
 
     function pullToken(address token, uint256 amount) external;

--- a/test/SpenderAaveV2Delegation.t.sol
+++ b/test/SpenderAaveV2Delegation.t.sol
@@ -60,12 +60,12 @@ contract SpenderAaveV2DelegationTest is Test {
     }
 
     // Cannot call spender directly
-    function testCannotExploit(uint128 amount) external {
+    function testCannotBeCalledByNonRouter(uint128 amount) external {
         vm.assume(amount > 0);
         deal(address(mockERC20), user, amount);
 
         vm.startPrank(user);
-        vm.expectRevert(ISpenderAaveV2Delegation.RouterInvalidUser.selector);
+        vm.expectRevert(ISpenderAaveV2Delegation.InvalidRouter.selector);
         spender.borrow(address(mockERC20), amount, uint256(InterestRateMode.VARIABLE));
         vm.stopPrank();
     }


### PR DESCRIPTION
Remove the check of router user initialization. Instead, requires the spender to be called only by router to prevent unexpected behavior.