### PR TITLE
fix: Received amount of output tokens

### DIFF
--- a/src/Router.sol
+++ b/src/Router.sol
@@ -99,12 +99,11 @@ contract Router is IRouter {
                 }
             }
 
-            // Store initial output token amount
+            // Store initial output token balances
             uint256 outputsLength = outputs.length;
-            uint256[] memory outputInitBalance = new uint256[](outputsLength);
+            uint256[] memory outputInitBalances = new uint256[](outputsLength);
             for (uint256 j = 0; j < outputsLength; ) {
-                address token = outputs[j].token;
-                outputInitBalance[j] = _getBalance(token);
+                outputInitBalances[j] = _getBalance(outputs[j].token);
 
                 unchecked {
                     j++;
@@ -133,7 +132,7 @@ contract Router is IRouter {
             for (uint256 j = 0; j < outputsLength; ) {
                 address token = outputs[j].token;
                 uint256 amountMin = outputs[j].amountMin;
-                uint256 balance = _getBalance(token) - outputInitBalance[j];
+                uint256 balance = _getBalance(token) - outputInitBalances[j];
 
                 // Check min amount
                 if (balance < amountMin) revert InsufficientBalance(address(token), amountMin, balance);

--- a/test/Router.t.sol
+++ b/test/Router.t.sol
@@ -41,40 +41,11 @@ contract RouterTest is Test {
         vm.label(address(spender), 'SpenderERC20Approval');
     }
 
-    function testCannotReceiveLessOutputToken() external {
-        IERC20 tokenOut = mockERC20;
-        uint256 amount;
-        uint256 amountMin;
-        amount = amountMin = 1 ether;
-        IRouter.Logic[] memory logics = new IRouter.Logic[](1);
-        IRouter.Output[] memory outputs = new IRouter.Output[](1);
-
-        // Output token already exists in router
-        deal(address(tokenOut), address(router), 10 ether);
-
-        outputs[0] = IRouter.Output(address(tokenOut), amountMin);
-
-        // Receive 0 output token
-        logics[0] = IRouter.Logic(
-            address(mockERC20), // to
-            abi.encodeWithSelector(MockERC20.mint.selector, address(router), 0),
-            inputsEmpty,
-            outputs,
-            address(0) // callback
-        );
-
-        // Execute
-        address[] memory tokensReturn = new address[](1);
-        tokensReturn[0] = address(tokenOut);
-        vm.expectRevert(abi.encodeWithSelector(IRouter.InsufficientBalance.selector, address(tokenOut), amountMin, 0));
-        router.execute(logics, tokensReturn);
-    }
-
     function testCannotExecuteByInvalidCallback() external {
         IRouter.Logic[] memory callbacks = new IRouter.Logic[](1);
         callbacks[0] = IRouter.Logic(
             address(mockERC20), // to
-            abi.encodeWithSelector(IERC20.totalSupply.selector),
+            abi.encodeWithSelector(MockERC20.dummy.selector),
             inputsEmpty,
             outputsEmpty,
             address(0) // callback
@@ -163,12 +134,39 @@ contract RouterTest is Test {
         IRouter.Logic[] memory logics = new IRouter.Logic[](1);
         logics[0] = IRouter.Logic(
             address(mockERC20), // to
-            abi.encodeWithSelector(IERC20.totalSupply.selector),
+            abi.encodeWithSelector(MockERC20.dummy.selector),
             inputsEmpty,
             outputsEmpty,
             address(router) // callback
         );
         vm.expectRevert(IRouter.UnresetCallback.selector);
         router.execute(logics, tokensReturnEmpty);
+    }
+
+    function testCannotReceiveLessOutputToken() external {
+        IERC20 tokenOut = mockERC20;
+        uint256 amountMin = 1 ether;
+        IRouter.Logic[] memory logics = new IRouter.Logic[](1);
+        IRouter.Output[] memory outputs = new IRouter.Output[](1);
+
+        // Output token already exists in router
+        deal(address(tokenOut), address(router), 10 ether);
+
+        outputs[0] = IRouter.Output(address(tokenOut), amountMin);
+
+        // Receive 0 output token
+        logics[0] = IRouter.Logic(
+            address(mockERC20), // to
+            abi.encodeWithSelector(MockERC20.dummy.selector),
+            inputsEmpty,
+            outputs,
+            address(0) // callback
+        );
+
+        // Execute
+        address[] memory tokensReturn = new address[](1);
+        tokensReturn[0] = address(tokenOut);
+        vm.expectRevert(abi.encodeWithSelector(IRouter.InsufficientBalance.selector, address(tokenOut), amountMin, 0));
+        router.execute(logics, tokensReturn);
     }
 }

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -6,7 +6,5 @@ import {ERC20} from 'openzeppelin-contracts/contracts/token/ERC20/ERC20.sol';
 contract MockERC20 is ERC20 {
     constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
 
-    function mint(address _to, uint256 _amount) public {
-        _mint(_to, _amount);
-    }
+    function dummy() external {}
 }


### PR DESCRIPTION
Router assumes the balance of output tokens are 0 before executing logics.
If the output token balance is not 0 (eg. the same token is provided in both input token and output token), the amountMin check could be bypassed.
