### PR TITLE
[WIP] Add Router::execute gas benchmark

### DIFF
--- a/test/gas/GasRouterExecute.t.sol
+++ b/test/gas/GasRouterExecute.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Test} from 'forge-std/Test.sol';
+import {Router, IRouter} from '../../src/Router.sol';
+import {MockFallback} from '../mocks/MockFallback.sol';
+
+contract GasRouterExecuteTest is Test {
+    address public user;
+    IRouter public router;
+    address public mockFallback;
+
+    // Empty arrays
+    address[] tokensReturnEmpty;
+    IRouter.Input[] inputsEmpty;
+    IRouter.Output[] outputsEmpty;
+
+    function setUp() external {
+        user = makeAddr('User');
+
+        router = new Router();
+        mockFallback = address(new MockFallback());
+
+        vm.label(address(router), 'Router');
+        vm.label(address(mockFallback), 'mFallback');
+    }
+
+    function testGas() external {
+        IRouter.Logic[] memory logics = new IRouter.Logic[](1);
+        logics[0] = IRouter.Logic(
+            address(mockFallback),
+            '',
+            inputsEmpty,
+            outputsEmpty,
+            address(0), // approveTo
+            address(0) // callback
+        );
+        vm.prank(user);
+        router.execute(logics, tokensReturnEmpty);
+    }
+}

--- a/test/gas/GasRouterExecuteCallback.t.sol
+++ b/test/gas/GasRouterExecuteCallback.t.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Test} from 'forge-std/Test.sol';
+import {Router, IRouter} from '../../src/Router.sol';
+import {ICallback, MockCallback} from '../mocks/MockCallback.sol';
+import {MockFallback} from '../mocks/MockFallback.sol';
+
+contract GasRouterExecuteCallbackTest is Test {
+    address public user;
+    IRouter public router;
+    ICallback public mockCallback;
+    address public mockFallback;
+
+    // Empty arrays
+    address[] tokensReturnEmpty;
+    IRouter.Input[] inputsEmpty;
+    IRouter.Output[] outputsEmpty;
+
+    function setUp() external {
+        user = makeAddr('User');
+
+        router = new Router();
+        mockCallback = new MockCallback();
+        mockFallback = address(new MockFallback());
+
+        vm.label(address(router), 'Router');
+        vm.label(address(mockCallback), 'mCallback');
+        vm.label(address(mockFallback), 'mFallback');
+    }
+
+    function testGas() external {
+        IRouter.Logic[] memory callbacks = new IRouter.Logic[](1);
+        callbacks[0] = IRouter.Logic(
+            address(mockFallback), // to
+            '',
+            inputsEmpty,
+            outputsEmpty,
+            address(0), // approveTo
+            address(0) // callback
+        );
+        bytes memory data = abi.encodeWithSelector(IRouter.execute.selector, callbacks, tokensReturnEmpty);
+        IRouter.Logic[] memory logics = new IRouter.Logic[](1);
+        logics[0] = IRouter.Logic(
+            address(mockCallback),
+            abi.encodeWithSelector(ICallback.callback.selector, data),
+            inputsEmpty,
+            outputsEmpty,
+            address(0), // approveTo
+            address(mockCallback) // callback
+        );
+        vm.prank(user);
+        router.execute(logics, tokensReturnEmpty);
+    }
+}

--- a/test/gas/GasRouterExecuteSpender.t.sol
+++ b/test/gas/GasRouterExecuteSpender.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Test} from 'forge-std/Test.sol';
+import {Router, IRouter} from '../../src/Router.sol';
+import {MockSpender} from '../mocks/MockSpender.sol';
+
+contract GasRouterExecuteSpenderTest is Test {
+    address public user;
+    IRouter public router;
+    address public mockSpender;
+
+    // Empty arrays
+    address[] tokensReturnEmpty;
+    IRouter.Input[] inputsEmpty;
+    IRouter.Output[] outputsEmpty;
+
+    function setUp() external {
+        user = makeAddr('User');
+
+        router = new Router();
+        mockSpender = address(new MockSpender(address(router)));
+
+        vm.label(address(router), 'Router');
+        vm.label(address(mockSpender), 'mSpender');
+    }
+
+    function testGas() external {
+        IRouter.Logic[] memory logics = new IRouter.Logic[](1);
+        logics[0] = IRouter.Logic(
+            address(mockSpender),
+            '',
+            inputsEmpty,
+            outputsEmpty,
+            address(0), // approveTo
+            address(0) // callback
+        );
+        vm.prank(user);
+        router.execute(logics, tokensReturnEmpty);
+    }
+}

--- a/test/mocks/MockSpender.sol
+++ b/test/mocks/MockSpender.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+import {Address} from 'openzeppelin-contracts/contracts/utils/Address.sol';
+import {IRouter} from '../../src/interfaces/IRouter.sol';
+
+contract MockSpender {
+    using Address for address;
+
+    address public immutable router;
+
+    constructor(address router_) {
+        router = router_;
+    }
+
+    fallback() external {
+        if (msg.sender != router) revert();
+        (bool success, ) = (msg.sender).staticcall(abi.encodeWithSelector(IRouter.user.selector));
+        require(success);
+    }
+}


### PR DESCRIPTION
`forge test --match-path ./test/gas/GasRouterExecute.t.sol --gas-report`
`Gas: 12056`
| Function Name                  | min             | avg   | median | max   | # calls |
| execute                        | 12056           | 12056 | 12056  | 12056 | 1       |

`forge test --match-path ./test/gas/GasRouterExecuteSpender.t.sol --gas-report`
`Gas: 12977`
| Function Name                  | min             | avg   | median | max   | # calls |
| execute                        | 12977           | 12977 | 12977  | 12977 | 1       |

`forge test --match-path ./test/gas/GasRouterExecuteCallback.t.sol --gas-report`
`Gas: 24040`
| Function Name                  | min             | avg   | median | max   | # calls |
| execute                        | 6357            | 15198 | 15198  | 24040 | 2       |