### PR TITLE
Chained Return Value

### DIFF
--- a/src/interfaces/IParam.sol
+++ b/src/interfaces/IParam.sol
@@ -4,17 +4,19 @@ pragma solidity ^0.8.0;
 interface IParam {
     struct Logic {
         address to;
+        uint256 value; // amount of native token
         bytes data;
         Input[] inputs;
         address callback;
+        bool chained; // flag for saving ret value
     }
 
     struct Input {
-        address token;
-        // 7_000 means the replacing amount is 70% of token balance. Set type(uint256).max to skip bps calculation so simply use amountOrOffset as amount
-        uint256 amountBps;
-        // If amountBps is skip, can simply read amountOrOffset as amount
-        // If amountBps is not skip, amountOrOffset is byte offset of amount in Logic.data used for replacement. Set type(uint256).max to skip if don't need to replace.
-        uint256 amountOrOffset;
+        uint256 index; // index of chained ret value
+        uint256 valueOffset; // offset of the native token amount
+        uint256 valueBps; // 7_000 means the replacing amount is 70% of token balance
+        uint256[] retOffsets; // return data offsets
+        uint256[] dataOffsets; // replaced data offsets
+        uint256[] amountBps; // 7_000 means the replacing amount is 70% of token balance
     }
 }


### PR DESCRIPTION
Overview:

Chained Return Value mechanism stores `to.function()` return values as bytes in memory. If the encoder wants to reuse the return values, the encoder should provide
  * the index of the return value.
  * the byte offset of the return value.
  * the byte offset of the data.

Walk-Through:
* The memory array `retValues` to store the `to.function()` return values (as bytes) for any following logic to use.
* Encoder decides whether to save the `to.function()` return value by setting the `chained` flag.
* Encoder decides whether to provide `data` / `msg.value` directly or to replace `data` / `msg.value` with ret values.
* The` msg.value` offset of a return data is specified in `valueOffset` and the bps is specified in `valueBps`.
* The replaced data offset is specified in the array `dataOffsets` and the return value offset is specified in the array `retOffsets`.
* If an encoder wants to reuse any return value, the `inputs.length` should > 0. Otherwise the `inputs.length` == 0.

Open Discussion
* Is the offset concept too complex for general encoders?
* Is there a better design to replace msg.value by return value? 
* Do we need to consider replacing data with return values saved by different logics?