### PR TITLE
Add fees parameters to execute functions

### DIFF
--- a/src/Router.sol
+++ b/src/Router.sol
@@ -188,6 +188,7 @@ contract Router is IRouter, EIP712, Ownable {
     /// @notice Execute logics through user's agent. Create agent for user if not created.
     function execute(
         IParam.Logic[] calldata logics,
+        IParam.Fee[] calldata fees,
         address[] calldata tokensReturn,
         uint256 referral
     ) external payable isPaused checkCaller {

--- a/src/interfaces/IParam.sol
+++ b/src/interfaces/IParam.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 interface IParam {
     struct LogicBatch {
         Logic[] logics;
+        Fee[] fees;
         uint256 deadline;
     }
 
@@ -24,6 +25,12 @@ interface IParam {
         // If amountBps is skip, can simply read amountOrOffset as amount
         // If amountBps is not skip, amountOrOffset is byte offset of amount in Logic.data used for replacement. Set type(uint256).max to skip if don't need to replace.
         uint256 amountOrOffset;
+    }
+
+    struct Fee {
+        address token;
+        uint256 amount;
+        bytes32 metadata;
     }
 
     enum WrapMode {

--- a/src/interfaces/IRouter.sol
+++ b/src/interfaces/IRouter.sol
@@ -90,6 +90,7 @@ interface IRouter {
 
     function execute(
         IParam.Logic[] calldata logics,
+        IParam.Fee[] calldata fees,
         address[] calldata tokensReturn,
         uint256 referral
     ) external payable;

--- a/test/LogicTypehash.t.sol
+++ b/test/LogicTypehash.t.sol
@@ -31,9 +31,9 @@ contract LogicTypehash is Test, LogicSignature {
 
     function testLogicBatchTypehash() external {
         // Signed a logicBatch using metamask to obtain an external sig
-        bytes32 r = 0x230bc3f8128e8ea2fe9debb87e63aa36c20e25e6eb8ac38452667031a4ca0819;
-        bytes32 s = 0x632a3e53640ad6ed3ffa32a91ba0485a12a5b1b2b54d600afa280fbca78a27c2;
-        uint8 v = 0x1b;
+        bytes32 r = 0xb2155e489c35b747610457550a11899e775bc4a1681260baaffc92b30c8bc892;
+        bytes32 s = 0x492c85b3613440c640debdc2cbf6ff960de6a363e238f42e0b7612229f2cc57b;
+        uint8 v = 0x1c;
         bytes memory sig = bytes.concat(r, s, bytes1(v));
 
         // Create the logicBatch with the same parameters as above
@@ -41,7 +41,7 @@ contract LogicTypehash is Test, LogicSignature {
         inputs[0] = IParam.Input(
             address(1), // token
             type(uint256).max, // amountBps
-            0 // amountOrOffset
+            1 // amountOrOffset
         );
         inputs[1] = IParam.Input(
             address(2), // token
@@ -58,8 +58,11 @@ contract LogicTypehash is Test, LogicSignature {
             address(5) // callback
         );
         logics[1] = logics[0]; // Duplicate logic
+        IParam.Fee[] memory fees = new IParam.Fee[](2);
+        fees[0] = IParam.Fee(address(6), 1, bytes32(abi.encodePacked('metadata')));
+        fees[1] = fees[0]; // Duplicate fee
         uint256 deadline = 1704067200;
-        IParam.LogicBatch memory logicBatch = IParam.LogicBatch(logics, deadline);
+        IParam.LogicBatch memory logicBatch = IParam.LogicBatch(logics, fees, deadline);
 
         // Verify the locally generated signature using the private key is the same as the external sig
         assertEq(getLogicBatchSignature(logicBatch, _buildDomainSeparator(), PRIVATE_KEY), sig);

--- a/test/integration/AaveV2.t.sol
+++ b/test/integration/AaveV2.t.sol
@@ -63,6 +63,7 @@ contract AaveV2IntegrationTest is Test {
 
     // Empty arrays
     address[] public tokensReturnEmpty;
+    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -109,7 +110,7 @@ contract AaveV2IntegrationTest is Test {
         address[] memory tokensReturn = new address[](1);
         tokensReturn[0] = address(tokenOut);
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         assertEq(tokenOut.balanceOf(address(router)), 0);
         assertEq(tokenOut.balanceOf(address(agent)), 0);
@@ -137,7 +138,7 @@ contract AaveV2IntegrationTest is Test {
 
         // Execute
         vm.prank(user);
-        router.execute(logics, tokensReturnEmpty, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturnEmpty, SIGNER_REFERRAL);
 
         assertEq(token.balanceOf(address(router)), 0);
         assertEq(token.balanceOf(address(agent)), 0);

--- a/test/integration/AaveV3.t.sol
+++ b/test/integration/AaveV3.t.sol
@@ -65,6 +65,7 @@ contract AaveV3IntegrationTest is Test {
 
     // Empty arrays
     address[] public tokensReturnEmpty;
+    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -111,7 +112,7 @@ contract AaveV3IntegrationTest is Test {
         address[] memory tokensReturn = new address[](1);
         tokensReturn[0] = address(tokenOut);
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         assertEq(tokenOut.balanceOf(address(router)), 0);
         assertEq(tokenOut.balanceOf(address(agent)), 0);
@@ -139,7 +140,7 @@ contract AaveV3IntegrationTest is Test {
 
         // Execute
         vm.prank(user);
-        router.execute(logics, tokensReturnEmpty, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturnEmpty, SIGNER_REFERRAL);
 
         assertEq(token.balanceOf(address(router)), 0);
         assertEq(token.balanceOf(address(agent)), 0);

--- a/test/integration/BalancerV2.t.sol
+++ b/test/integration/BalancerV2.t.sol
@@ -30,6 +30,7 @@ contract BalancerV2IntegrationTest is Test {
 
     // Empty arrays
     address[] public tokensReturnEmpty;
+    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -61,7 +62,7 @@ contract BalancerV2IntegrationTest is Test {
 
         // Execute
         vm.prank(user);
-        router.execute(logics, tokensReturnEmpty, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturnEmpty, SIGNER_REFERRAL);
 
         address agent = router.getAgent(user);
         assertEq(token.balanceOf(address(router)), 0);

--- a/test/integration/ERC1155Market.t.sol
+++ b/test/integration/ERC1155Market.t.sol
@@ -28,6 +28,7 @@ contract ERC1155MarketTest is Test, SpenderPermitUtils, SpenderERC1155Utils {
     MockERC1155Market public market;
 
     // Empty arrays
+    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -67,7 +68,7 @@ contract ERC1155MarketTest is Test, SpenderPermitUtils, SpenderERC1155Utils {
 
         // Execute
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         // Verify
         assertEq(tokenIn.balanceOf(address(router)), 0);
@@ -99,7 +100,7 @@ contract ERC1155MarketTest is Test, SpenderPermitUtils, SpenderERC1155Utils {
         // Execute
         uint256 tokenBefore = tokenIn.balanceOf(user);
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         // Verify
         assertEq(tokenIn.balanceOf(address(router)), 0);
@@ -125,7 +126,7 @@ contract ERC1155MarketTest is Test, SpenderPermitUtils, SpenderERC1155Utils {
 
         // Execute
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         // Verify
         assertEq(tokenIn.balanceOf(address(router)), 0);
@@ -157,7 +158,7 @@ contract ERC1155MarketTest is Test, SpenderPermitUtils, SpenderERC1155Utils {
         // Execute
         uint256 tokenBefore = tokenIn.balanceOf(user);
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         // Verify
         assertEq(tokenIn.balanceOf(address(router)), 0);

--- a/test/integration/ERC721Market.t.sol
+++ b/test/integration/ERC721Market.t.sol
@@ -28,6 +28,7 @@ contract ERC721MarketTest is Test, SpenderPermitUtils, SpenderERC721Utils {
     MockERC721Market public market;
 
     // Empty arrays
+    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -67,7 +68,7 @@ contract ERC721MarketTest is Test, SpenderPermitUtils, SpenderERC721Utils {
 
         // Execute
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         // Verify
         assertEq(tokenIn.balanceOf(address(router)), 0);
@@ -99,7 +100,7 @@ contract ERC721MarketTest is Test, SpenderPermitUtils, SpenderERC721Utils {
         // Execute
         uint256 tokenBefore = tokenIn.balanceOf(user);
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         // Verify
         assertEq(tokenIn.balanceOf(address(router)), 0);

--- a/test/integration/UniswapV2.t.sol
+++ b/test/integration/UniswapV2.t.sol
@@ -67,6 +67,7 @@ contract UniswapV2Test is Test, SpenderPermitUtils {
     IAgent public agent;
 
     // Empty arrays
+    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -108,7 +109,7 @@ contract UniswapV2Test is Test, SpenderPermitUtils {
         address[] memory tokensReturn = new address[](1);
         tokensReturn[0] = address(tokenOut);
         vm.prank(user);
-        router.execute{value: amountIn}(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute{value: amountIn}(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         assertEq(address(router).balance, 0);
         assertEq(address(agent).balance, 0);
@@ -135,7 +136,7 @@ contract UniswapV2Test is Test, SpenderPermitUtils {
         address[] memory tokensReturn = new address[](1);
         tokensReturn[0] = NATIVE;
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         assertEq(address(router).balance, 0);
         assertEq(address(agent).balance, 0);
@@ -161,7 +162,7 @@ contract UniswapV2Test is Test, SpenderPermitUtils {
         address[] memory tokensReturn = new address[](1);
         tokensReturn[0] = address(tokenOut);
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         assertEq(tokenIn.balanceOf(address(router)), 0);
         assertEq(tokenIn.balanceOf(address(agent)), 0);
@@ -197,7 +198,7 @@ contract UniswapV2Test is Test, SpenderPermitUtils {
         tokensReturn[1] = address(tokenIn1); // Push intermediate token to ensure clean up Agent
         tokensReturn[2] = address(tokenOut); // Push intermediate token to ensure clean up Agent
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         assertEq(tokenIn0.balanceOf(address(router)), 0);
         assertEq(tokenIn0.balanceOf(address(agent)), 0);

--- a/test/integration/UniswapV3.t.sol
+++ b/test/integration/UniswapV3.t.sol
@@ -114,8 +114,9 @@ contract UniswapV3Test is Test, SpenderPermitUtils, SpenderERC721Utils {
     uint128 liquidity;
 
     // Empty arrays
-    IParam.Input[] public inputsEmpty;
     address[] public tokensReturnEmpty;
+    IParam.Fee[] public feesEmpty;
+    IParam.Input[] public inputsEmpty;
 
     function setUp() external {
         (user, userPrivateKey) = makeAddrAndKey('User');
@@ -186,7 +187,7 @@ contract UniswapV3Test is Test, SpenderPermitUtils, SpenderERC721Utils {
 
         // Execute
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         // Verify
         assertEq(tokenIn0.balanceOf(address(router)), 0);
@@ -257,7 +258,7 @@ contract UniswapV3Test is Test, SpenderPermitUtils, SpenderERC721Utils {
 
         // Execute
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         // Verify
         (, , , , , , , uint128 newLiquidity, , , , ) = NON_FUNGIBLE_POSITION_MANAGER.positions(tokenId);
@@ -328,7 +329,7 @@ contract UniswapV3Test is Test, SpenderPermitUtils, SpenderERC721Utils {
 
         // Execute remove liquidity action
         vm.prank(user);
-        router.execute(logics, tokensReturnEmpty, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturnEmpty, SIGNER_REFERRAL);
 
         // Verify remove liquidity
         (
@@ -378,7 +379,7 @@ contract UniswapV3Test is Test, SpenderPermitUtils, SpenderERC721Utils {
         userToken0Before = tokenIn0.balanceOf(user);
         userToken1Before = tokenIn1.balanceOf(user);
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         // Verify result of collect action
         assertEq(tokenIn0.balanceOf(address(router)), 0);

--- a/test/integration/WrappedNative.t.sol
+++ b/test/integration/WrappedNative.t.sol
@@ -20,6 +20,9 @@ contract WrappedNativeTest is Test {
     address public user;
     IRouter public router;
 
+    // Empty arrays
+    IParam.Fee[] public feesEmpty;
+
     function setUp() external {
         user = makeAddr('User');
         router = new Router(address(WRAPPED_NATIVE), makeAddr('Pauser'), makeAddr('FeeCollector'));
@@ -48,7 +51,7 @@ contract WrappedNativeTest is Test {
         tokensReturn[0] = tokenIn;
         tokensReturn[1] = address(tokenOut);
         vm.prank(user);
-        router.execute{value: amountIn}(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute{value: amountIn}(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         address agent = router.getAgent(user);
         assertEq(address(router).balance, 0);

--- a/test/integration/YearnV2.t.sol
+++ b/test/integration/YearnV2.t.sol
@@ -29,6 +29,7 @@ contract YearnV2Test is Test, SpenderPermitUtils {
     IAgent public agent;
 
     // Empty arrays
+    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -61,7 +62,7 @@ contract YearnV2Test is Test, SpenderPermitUtils {
         address[] memory tokensReturn = new address[](1);
         tokensReturn[0] = address(tokenOut);
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         assertEq(tokenIn.balanceOf(address(router)), 0);
         assertEq(tokenIn.balanceOf(address(agent)), 0);

--- a/test/integration/maker/AgentMakerAction.t.sol
+++ b/test/integration/maker/AgentMakerAction.t.sol
@@ -33,6 +33,7 @@ contract AgentMakerActionTest is Test, MakerCommonUtils, SpenderPermitUtils {
 
     // Empty arrays
     address[] public tokensReturnEmpty;
+    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -51,7 +52,7 @@ contract AgentMakerActionTest is Test, MakerCommonUtils, SpenderPermitUtils {
 
         // Build user agent's DSProxy
         userAgent = IAgent(router.newAgent());
-        router.execute(_logicBuildAgentDSProxy(), new address[](0), SIGNER_REFERRAL);
+        router.execute(_logicBuildAgentDSProxy(), feesEmpty, tokensReturnEmpty, SIGNER_REFERRAL);
         userAgentDSProxy = IDSProxyRegistry(PROXY_REGISTRY).proxies(address(userAgent));
 
         // Open ETH Vault
@@ -101,7 +102,7 @@ contract AgentMakerActionTest is Test, MakerCommonUtils, SpenderPermitUtils {
         // Build user2's agent
         vm.startPrank(user2);
         user2Agent = IAgent(router.newAgent());
-        router.execute(_logicBuildAgentDSProxy(), new address[](0), SIGNER_REFERRAL);
+        router.execute(_logicBuildAgentDSProxy(), feesEmpty, tokensReturnEmpty, SIGNER_REFERRAL);
         user2AgentDSProxy = IDSProxyRegistry(PROXY_REGISTRY).proxies(address(user2Agent));
         vm.stopPrank();
 
@@ -134,7 +135,7 @@ contract AgentMakerActionTest is Test, MakerCommonUtils, SpenderPermitUtils {
 
         // Execute
         vm.prank(user2);
-        router.execute{value: lockETHAmount}(logics, tokensReturnEmpty, SIGNER_REFERRAL);
+        router.execute{value: lockETHAmount}(logics, feesEmpty, tokensReturnEmpty, SIGNER_REFERRAL);
 
         (, uint256 collateralAfter) = _getCdpInfo(ethCdp);
 
@@ -158,7 +159,7 @@ contract AgentMakerActionTest is Test, MakerCommonUtils, SpenderPermitUtils {
         address[] memory tokensReturn = new address[](1);
         tokensReturn[0] = address(NATIVE);
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         assertEq(user.balance - userEthBalanceBefore, freeETHAmount);
         assertEq(address(router).balance, 0);
@@ -182,7 +183,7 @@ contract AgentMakerActionTest is Test, MakerCommonUtils, SpenderPermitUtils {
         address[] memory tokensReturn = new address[](1);
         tokensReturn[0] = address(NATIVE);
         vm.prank(user2);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         assertEq(user2.balance - user2EthBalanceBefore, freeETHAmount);
         assertEq(address(router).balance, 0);
@@ -202,7 +203,7 @@ contract AgentMakerActionTest is Test, MakerCommonUtils, SpenderPermitUtils {
         tokensReturn[0] = address(NATIVE);
         vm.expectRevert('ERROR_ROUTER_EXECUTE');
         vm.prank(user2);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
     }
 
     function testLockGem() external {
@@ -220,7 +221,7 @@ contract AgentMakerActionTest is Test, MakerCommonUtils, SpenderPermitUtils {
 
         // Execute
         vm.prank(user2);
-        router.execute(logics, tokensReturnEmpty, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturnEmpty, SIGNER_REFERRAL);
 
         (, uint256 collateralAfter) = _getCdpInfo(gemCdp);
         uint256 user2GemBalanceAfter = IERC20(GEM).balanceOf(user2);
@@ -245,7 +246,7 @@ contract AgentMakerActionTest is Test, MakerCommonUtils, SpenderPermitUtils {
         address[] memory tokensReturn = new address[](1);
         tokensReturn[0] = address(GEM);
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         uint256 userEthBalanceAfter = IERC20(GEM).balanceOf(user);
 
@@ -269,7 +270,7 @@ contract AgentMakerActionTest is Test, MakerCommonUtils, SpenderPermitUtils {
 
         // Execute
         vm.prank(user2);
-        router.execute(logics, tokensReturnEmpty, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturnEmpty, SIGNER_REFERRAL);
 
         (uint256 debtAfter, ) = _getCdpInfo(gemCdp);
         uint256 user2DaiBalanceAfter = IERC20(DAI_TOKEN).balanceOf(user2);
@@ -298,7 +299,7 @@ contract AgentMakerActionTest is Test, MakerCommonUtils, SpenderPermitUtils {
         address[] memory tokensReturn = new address[](1);
         tokensReturn[0] = address(DAI_TOKEN);
         vm.prank(user2);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         (uint256 debtAfter, ) = _getCdpInfo(gemCdp);
         uint256 user2DaiBalanceAfter = IERC20(DAI_TOKEN).balanceOf(user2);
@@ -323,7 +324,7 @@ contract AgentMakerActionTest is Test, MakerCommonUtils, SpenderPermitUtils {
         address[] memory tokensReturn = new address[](1);
         tokensReturn[0] = address(DAI_TOKEN);
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         uint256 userDaiBalanceAfter = IERC20(DAI_TOKEN).balanceOf(user);
 

--- a/test/integration/maker/UtilityMaker.t.sol
+++ b/test/integration/maker/UtilityMaker.t.sol
@@ -27,6 +27,7 @@ contract UtilityMakerTest is Test, MakerCommonUtils, SpenderPermitUtils {
 
     // Empty arrays
     address[] public tokensReturnEmpty;
+    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -79,7 +80,7 @@ contract UtilityMakerTest is Test, MakerCommonUtils, SpenderPermitUtils {
         address[] memory tokensReturn = new address[](1);
         tokensReturn[0] = address(DAI_TOKEN);
         vm.prank(user);
-        router.execute{value: ethLockAmount}(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute{value: ethLockAmount}(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         assertEq(IERC20(DAI_TOKEN).balanceOf(address(agent)), 0);
         assertEq(IERC20(DAI_TOKEN).balanceOf(address(utilityMaker)), 0);
@@ -117,7 +118,7 @@ contract UtilityMakerTest is Test, MakerCommonUtils, SpenderPermitUtils {
         address[] memory tokensReturn = new address[](1);
         tokensReturn[0] = address(DAI_TOKEN);
         vm.prank(user);
-        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
+        router.execute(logics, feesEmpty, tokensReturn, SIGNER_REFERRAL);
 
         assertEq(IERC20(DAI_TOKEN).balanceOf(address(agent)), 0);
         assertEq(IERC20(DAI_TOKEN).balanceOf(address(utilityMaker)), 0);

--- a/test/utils/SpenderPermitUtils.sol
+++ b/test/utils/SpenderPermitUtils.sol
@@ -41,7 +41,8 @@ contract SpenderPermitUtils is Test, PermitSignature {
 
         // Encode execute
         address[] memory tokensReturnEmpty;
-        _router.execute(logics, tokensReturnEmpty, SIGNER_REFERRAL);
+        IParam.Fee[] memory feesEmpty;
+        _router.execute(logics, feesEmpty, tokensReturnEmpty, SIGNER_REFERRAL);
         vm.stopPrank();
     }
 


### PR DESCRIPTION
`executeWithSignature` does not emit a fee event on-chain, which may make future analysis difficult. This PR firstly adds `fees` to two `execute` functions and updates the corresponding EIP-712 typehash. The code involving fees will be added in a subsequent PR.