### PR TITLE
Rename router user to currentUser and optimize gas for currentUser read

### DIFF
--- a/src/AgentImplementation.sol
+++ b/src/AgentImplementation.sol
@@ -47,7 +47,7 @@ contract AgentImplementation is IAgent, ERC721Holder, ERC1155Holder {
         _caller = router;
     }
 
-    /// @notice Execute logics and return tokens to user
+    /// @notice Execute logics and return tokens to the current user
     function execute(
         IParam.Logic[] calldata logics,
         IParam.Fee[] calldata fees,
@@ -60,7 +60,7 @@ contract AgentImplementation is IAgent, ERC721Holder, ERC1155Holder {
         // Push tokensReturn if any balance
         uint256 tokensReturnLength = tokensReturn.length;
         if (tokensReturnLength > 0) {
-            address user = IRouter(router).user();
+            address user = IRouter(router).currentUser();
             for (uint256 i = 0; i < tokensReturnLength; ) {
                 address token = tokensReturn[i];
                 if (token == _NATIVE) {

--- a/src/interfaces/IRouter.sol
+++ b/src/interfaces/IRouter.sol
@@ -19,7 +19,7 @@ interface IRouter {
 
     event Execute(address indexed user, address indexed agent, uint256 indexed referralCode);
 
-    event AgentCreated(address indexed agent, address indexed owner);
+    event AgentCreated(address indexed agent, address indexed user);
 
     error Reentrancy();
 
@@ -43,11 +43,11 @@ interface IRouter {
 
     function agentImplementation() external view returns (address);
 
-    function agents(address owner) external view returns (IAgent);
+    function agents(address user) external view returns (IAgent);
 
     function signers(address signer) external view returns (bool);
 
-    function user() external view returns (address);
+    function currentUser() external view returns (address);
 
     function feeCollector() external view returns (address);
 

--- a/test/Router.t.sol
+++ b/test/Router.t.sol
@@ -35,7 +35,7 @@ contract RouterTest is Test, LogicSignature {
     event PauserSet(address indexed pauser);
     event Paused();
     event Resumed();
-    event AgentCreated(address indexed agent, address indexed owner);
+    event AgentCreated(address indexed agent, address indexed user);
     event Execute(address indexed user, address indexed agent, uint256 indexed referralCode);
 
     function setUp() external {
@@ -357,7 +357,7 @@ contract RouterTest is Test, LogicSignature {
         vm.deal(address(this), value);
 
         vm.expectRevert();
-        (bool succ,) = address(router).call{value: value}('');
+        (bool succ, ) = address(router).call{value: value}('');
         assertTrue(succ);
     }
 }


### PR DESCRIPTION
- A more accurate representation of this 'user' refers to the user currently executing the transaction. This allows some functions in the Router to use the name 'user' for parameters, instead of 'owner_' or 'user_', which can be confusing.
- Optimize the gas cost for reading storage in `execute` and `executeWithSignature`