### PR TITLE
Add coverage and complete tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Composable Router contracts consist of the following components:
 
 `forge test --fork-url https://cloudflare-eth.com -vvv`
 
+### Coverage
+
+`forge coverage --rpc-url https://rpc.ankr.com/eth --report summary`
+
 ### Deploy All
 
 Fill out parameters in `script/deployParameters/<network>.json`

--- a/test/integration/maker/UtilityMaker.t.sol
+++ b/test/integration/maker/UtilityMaker.t.sol
@@ -91,6 +91,29 @@ contract MakerUtilityTest is Test, MakerCommonUtils, ERC20Permit2Utils {
         assertEq(IMakerManager(CDP_MANAGER).count(userDSProxy) - userCdpCountBefore, 1); // cdp count should increase by 1
     }
 
+    function testCannotOpenLockETHAndDrawByInvalidSender(uint256 ethLockAmount, uint256 daiDrawAmount) external {
+        // Calculate minimum collateral amount of ETH and drawing random amount of DAI between minimum and maximum
+        IMakerVat vat = IMakerVat(VAT);
+        bytes32 ilkETH = bytes32(bytes(ETH_JOIN_NAME));
+        (, uint256 rate, uint256 spot, , uint256 dust) = vat.ilks(ilkETH);
+        (uint256 daiDrawMin, uint256 minCollateral) = _getDAIDrawMinAndMinCollateral(spot, dust);
+
+        ethLockAmount = bound(ethLockAmount, minCollateral, 1e22);
+        deal(user, ethLockAmount);
+        uint256 daiDrawMax = _getDAIDrawMaxAmount(ethLockAmount, daiDrawMin, spot, rate);
+        daiDrawAmount = bound(daiDrawAmount, daiDrawMin, daiDrawMax);
+
+        vm.prank(user);
+        vm.expectRevert(IMakerUtility.InvalidAgent.selector);
+        makerUtility.openLockETHAndDraw(
+            ethLockAmount,
+            ETH_JOIN_A,
+            DAI_JOIN,
+            bytes32(bytes(ETH_JOIN_NAME)),
+            daiDrawAmount
+        );
+    }
+
     function testOpenLockGemAndDraw(uint256 tokenLockAmount, uint256 daiDrawAmount) external {
         // Calculate minimum collateral amount of token and drawing random amount of DAI between minimum and maximum
         IMakerVat vat = IMakerVat(VAT);
@@ -129,11 +152,29 @@ contract MakerUtilityTest is Test, MakerCommonUtils, ERC20Permit2Utils {
         assertEq(IMakerManager(CDP_MANAGER).count(userDSProxy) - userCdpCountBefore, 1); // cdp count should increase by 1
     }
 
-    function _getDAIDrawMinAndMinCollateral(
-        uint256 spot,
-        uint256 dust,
-        uint256 collateralDecimal
-    ) internal pure returns (uint256, uint256) {
+    function testCannotOpenLockGemAndDrawByInvalidSender(uint256 tokenLockAmount, uint256 daiDrawAmount) external {
+        // Calculate minimum collateral amount of token and drawing random amount of DAI between minimum and maximum
+        IMakerVat vat = IMakerVat(VAT);
+        bytes32 ilkToken = bytes32(bytes(TOKEN_JOIN_NAME));
+        (, uint256 rate, uint256 spot, , uint256 dust) = vat.ilks(ilkToken);
+        (uint256 daiDrawMin, uint256 minCollateral) = _getDAIDrawMinAndMinCollateral(spot, dust);
+
+        tokenLockAmount = bound(tokenLockAmount, minCollateral, 1e23);
+        deal(GEM, user, tokenLockAmount);
+        uint256 daiDrawMax = _getDAIDrawMaxAmount(tokenLockAmount, daiDrawMin, spot, rate);
+        daiDrawAmount = bound(daiDrawAmount, daiDrawMin, daiDrawMax);
+        vm.prank(user);
+        vm.expectRevert(IMakerUtility.InvalidAgent.selector);
+        makerUtility.openLockGemAndDraw(
+            GEM_JOIN_LINK_A,
+            DAI_JOIN,
+            bytes32(bytes(TOKEN_JOIN_NAME)),
+            tokenLockAmount,
+            daiDrawAmount
+        );
+    }
+
+    function _getDAIDrawMinAndMinCollateral(uint256 spot, uint256 dust) internal pure returns (uint256, uint256) {
         uint256 daiDrawMin = dust / 1000000000 ether; // at least draw this much DAI
         uint256 minCollateral = dust / spot / (10 ** (18 - collateralDecimal));
         minCollateral = (minCollateral * 105) / 100; // 5% Buffer


### PR DESCRIPTION
Add the coverage command in README for developers to check unit test paths.

The coverage report is as below:

| File                                                | % Lines          | % Statements     | % Branches       | % Funcs         |
|-----------------------------------------------------|------------------|------------------|------------------|-----------------|
| src/Agent.sol                                       | 0.00% (0/1)      | 0.00% (0/1)      | 100.00% (0/0)    | 0.00% (0/2)     |
| src/AgentImplementation.sol                         | 100.00% (72/72)  | 98.81% (83/84)   | 85.00% (34/40)   | 100.00% (5/5)   |
| src/Router.sol                                      | 91.67% (44/48)   | 91.07% (51/56)   | 88.89% (16/18)   | 88.89% (16/18)  |
| src/callbacks/AaveV2FlashLoanCallback.sol           | 100.00% (18/18)  | 100.00% (26/26)  | 100.00% (4/4)    | 100.00% (1/1)   |
| src/callbacks/AaveV3FlashLoanCallback.sol           | 100.00% (18/18)  | 100.00% (26/26)  | 100.00% (4/4)    | 100.00% (1/1)   |
| src/callbacks/BalancerV2FlashLoanCallback.sol       | 100.00% (15/15)  | 100.00% (21/21)  | 100.00% (4/4)    | 100.00% (1/1)   |
| src/fees/AaveBorrowFeeCalculator.sol                | 100.00% (7/7)    | 100.00% (10/10)  | 100.00% (0/0)    | 100.00% (2/2)   |
| src/fees/AaveFlashLoanFeeCalculator.sol             | 100.00% (34/34)  | 100.00% (45/45)  | 83.33% (5/6)     | 100.00% (4/4)   |
| src/fees/BalancerFlashLoanFeeCalculator.sol         | 100.00% (32/32)  | 100.00% (43/43)  | 83.33% (5/6)     | 100.00% (4/4)   |
| src/fees/FeeCalculatorBase.sol                      | 100.00% (13/13)  | 100.00% (17/17)  | 100.00% (4/4)    | 60.00% (3/5)    |
| src/fees/FeeVerifier.sol                            | 87.91% (80/91)   | 89.23% (116/130) | 67.65% (23/34)   | 44.44% (4/9)    |
| src/fees/MakerDrawFeeCalculator.sol                 | 100.00% (13/13)  | 90.91% (20/22)   | 37.50% (3/8)     | 100.00% (2/2)   |
| src/fees/NativeFeeCalculator.sol                    | 100.00% (4/4)    | 100.00% (5/5)    | 100.00% (0/0)    | 100.00% (2/2)   |
| src/fees/Permit2FeeCalculator.sol                   | 100.00% (9/9)    | 92.86% (13/14)   | 50.00% (1/2)     | 100.00% (2/2)   |
| src/fees/TransferFromFeeCalculator.sol              | 100.00% (7/7)    | 100.00% (10/10)  | 100.00% (0/0)    | 100.00% (2/2)   |
| src/libraries/ApproveHelper.sol                     | 50.00% (2/4)     | 50.00% (2/4)     | 0.00% (0/4)      | 50.00% (1/2)    |
| src/libraries/LogicHash.sol                         | 0.00% (0/22)     | 0.00% (0/28)     | 100.00% (0/0)    | 0.00% (0/4)     |
| src/utilities/MakerUtility.sol                      | 56.25% (9/16)    | 60.87% (14/23)    | 75.00% (3/4)     | 100% (3/3)    |