### PR TITLE
Feature/fix issues from security contest 20230517

### DIFF
--- a/src/AgentImplementation.sol
+++ b/src/AgentImplementation.sol
@@ -76,7 +76,7 @@ contract AgentImplementation is IAgent, ERC721Holder, ERC1155Holder {
         uint256 tokensReturnLength = tokensReturn.length;
         if (tokensReturnLength > 0) {
             address user = IRouter(router).currentUser();
-            for (uint256 i = 0; i < tokensReturnLength; ) {
+            for (uint256 i; i < tokensReturnLength; ) {
                 address token = tokensReturn[i];
                 if (token == _NATIVE) {
                     payable(user).sendValue(address(this).balance);
@@ -103,7 +103,7 @@ contract AgentImplementation is IAgent, ERC721Holder, ERC1155Holder {
     function _executeLogics(IParam.Logic[] calldata logics) internal {
         // Execute each logic
         uint256 logicsLength = logics.length;
-        for (uint256 i = 0; i < logicsLength; ) {
+        for (uint256 i; i < logicsLength; ) {
             address to = logics[i].to;
             bytes memory data = logics[i].data;
             IParam.Input[] calldata inputs = logics[i].inputs;
@@ -119,7 +119,7 @@ contract AgentImplementation is IAgent, ERC721Holder, ERC1155Holder {
             uint256 value;
             uint256 wrappedAmount;
             uint256 inputsLength = inputs.length;
-            for (uint256 j = 0; j < inputsLength; ) {
+            for (uint256 j; j < inputsLength; ) {
                 address token = inputs[j].token;
                 uint256 balanceBps = inputs[j].balanceBps;
 
@@ -204,7 +204,7 @@ contract AgentImplementation is IAgent, ERC721Holder, ERC1155Holder {
         if (length == 0) return;
 
         address feeCollector = IRouter(router).feeCollector();
-        for (uint256 i = 0; i < length; ) {
+        for (uint256 i; i < length; ) {
             address token = fees[i].token;
             uint256 amount = fees[i].amount;
             if (token == _NATIVE) {

--- a/src/AgentImplementation.sol
+++ b/src/AgentImplementation.sol
@@ -132,7 +132,7 @@ contract AgentImplementation is IAgent, ERC721Holder, ERC1155Holder {
                 } else {
                     if (balanceBps == 0 || balanceBps > _BPS_BASE) revert InvalidBps();
 
-                    if (token == address(wrappedNative) && wrapMode == IParam.WrapMode.WRAP_BEFORE) {
+                    if (token == wrappedNative && wrapMode == IParam.WrapMode.WRAP_BEFORE) {
                         // Use the native balance for amount calculation as wrap will be executed later
                         amount = (address(this).balance * balanceBps) / _BPS_BASE;
                     } else {

--- a/src/Router.sol
+++ b/src/Router.sol
@@ -171,7 +171,7 @@ contract Router is IRouter, EIP712, FeeGenerator {
         IAgent agent = agents[user];
 
         if (address(agent) == address(0)) {
-            agent = IAgent(newAgent(user));
+            agent = IAgent(_newAgent(user));
         }
 
         IParam.Fee[] memory fees = getFeesByLogics(logics, msg.value);
@@ -205,7 +205,7 @@ contract Router is IRouter, EIP712, FeeGenerator {
         IAgent agent = agents[user];
 
         if (address(agent) == address(0)) {
-            agent = IAgent(newAgent(user));
+            agent = IAgent(_newAgent(user));
         }
 
         emit Execute(user, address(agent), referralCode);
@@ -225,11 +225,15 @@ contract Router is IRouter, EIP712, FeeGenerator {
         if (address(agents[user]) != address(0)) {
             revert AgentAlreadyCreated();
         } else {
-            IAgent agent = IAgent(address(new Agent{salt: bytes32(bytes20(user))}(agentImplementation)));
-            agents[user] = agent;
-            emit AgentCreated(address(agent), user);
-            return payable(address(agent));
+            return _newAgent(user);
         }
+    }
+
+    function _newAgent(address user) internal returns (address payable) {
+        IAgent agent = IAgent(address(new Agent{salt: bytes32(bytes20(user))}(agentImplementation)));
+        agents[user] = agent;
+        emit AgentCreated(address(agent), user);
+        return payable(address(agent));
     }
 
     /// @notice Set the fee collector address that collects fees from each user's agent by owner

--- a/src/Router.sol
+++ b/src/Router.sol
@@ -97,7 +97,7 @@ contract Router is IRouter, EIP712, FeeGenerator {
     /// @notice Get user and agent addresses of the current user
     /// @return The user address
     /// @return The agent address
-    function getUserAgent() external view returns (address, address) {
+    function getCurrentUserAgent() external view returns (address, address) {
         address user = currentUser;
         return (user, address(agents[user]));
     }

--- a/src/Router.sol
+++ b/src/Router.sol
@@ -229,11 +229,11 @@ contract Router is IRouter, EIP712, FeeGenerator {
         }
     }
 
-    function _newAgent(address user) internal returns (address payable) {
+    function _newAgent(address user) internal returns (address) {
         IAgent agent = IAgent(address(new Agent{salt: bytes32(bytes20(user))}(agentImplementation)));
         agents[user] = agent;
         emit AgentCreated(address(agent), user);
-        return payable(address(agent));
+        return address(agent);
     }
 
     /// @notice Set the fee collector address that collects fees from each user's agent by owner

--- a/src/Router.sol
+++ b/src/Router.sol
@@ -51,7 +51,7 @@ contract Router is IRouter, EIP712, FeeGenerator {
         currentUser = _INIT_USER;
     }
 
-    modifier isPaused() {
+    modifier whenNotPaused() {
         if (paused) revert RouterIsPaused();
         _;
     }
@@ -166,7 +166,7 @@ contract Router is IRouter, EIP712, FeeGenerator {
         IParam.Logic[] calldata logics,
         address[] calldata tokensReturn,
         uint256 referralCode
-    ) external payable isPaused checkCaller {
+    ) external payable whenNotPaused checkCaller {
         address user = currentUser;
         IAgent agent = agents[user];
 
@@ -194,7 +194,7 @@ contract Router is IRouter, EIP712, FeeGenerator {
         bytes calldata signature,
         address[] calldata tokensReturn,
         uint256 referralCode
-    ) external payable isPaused checkCaller {
+    ) external payable whenNotPaused checkCaller {
         // Verify deadline, signer and signature
         uint256 deadline = logicBatch.deadline;
         if (block.timestamp > deadline) revert SignatureExpired(deadline);

--- a/src/Router.sol
+++ b/src/Router.sol
@@ -113,7 +113,7 @@ contract Router is IRouter, EIP712, FeeGenerator {
                         abi.encodePacked(
                             bytes1(0xff),
                             address(this),
-                            bytes32(bytes20((uint160(user)))),
+                            bytes32(bytes20(user)),
                             keccak256(abi.encodePacked(type(Agent).creationCode, abi.encode(agentImplementation)))
                         )
                     )
@@ -225,7 +225,7 @@ contract Router is IRouter, EIP712, FeeGenerator {
         if (address(agents[user]) != address(0)) {
             revert AgentAlreadyCreated();
         } else {
-            IAgent agent = IAgent(address(new Agent{salt: bytes32(bytes20((uint160(user))))}(agentImplementation)));
+            IAgent agent = IAgent(address(new Agent{salt: bytes32(bytes20(user))}(agentImplementation)));
             agents[user] = agent;
             emit AgentCreated(address(agent), user);
             return payable(address(agent));

--- a/src/Router.sol
+++ b/src/Router.sol
@@ -151,10 +151,10 @@ contract Router is IRouter, EIP712, FeeGenerator {
         emit Paused();
     }
 
-    /// @notice Resume `execute` and `executeWithSignature` by pauser
-    function resume() external onlyPauser {
+    /// @notice Unpause `execute` and `executeWithSignature` by pauser
+    function unpause() external onlyPauser {
         paused = false;
-        emit Resumed();
+        emit Unpaused();
     }
 
     /// @notice Execute arbitrary logics through the current user's agent. Creates an agent for users if not created.

--- a/src/callbacks/AaveV2FlashLoanCallback.sol
+++ b/src/callbacks/AaveV2FlashLoanCallback.sol
@@ -42,7 +42,7 @@ contract AaveV2FlashLoanCallback is IAaveV2FlashLoanCallback {
         // Transfer assets to the agent and record initial balances
         uint256 assetsLength = assets.length;
         uint256[] memory initBalances = new uint256[](assetsLength);
-        for (uint256 i = 0; i < assetsLength; ) {
+        for (uint256 i; i < assetsLength; ) {
             address asset = assets[i];
 
             IERC20(asset).safeTransfer(agent, amounts[i]);
@@ -56,7 +56,7 @@ contract AaveV2FlashLoanCallback is IAaveV2FlashLoanCallback {
         agent.functionCall(abi.encodePacked(IAgent.execute.selector, params), 'ERROR_AAVE_V2_FLASH_LOAN_CALLBACK');
 
         // Approve assets for pulling from Aave Pool
-        for (uint256 i = 0; i < assetsLength; ) {
+        for (uint256 i; i < assetsLength; ) {
             address asset = assets[i];
             uint256 amountOwing = amounts[i] + premiums[i];
 

--- a/src/callbacks/AaveV2FlashLoanCallback.sol
+++ b/src/callbacks/AaveV2FlashLoanCallback.sol
@@ -37,7 +37,7 @@ contract AaveV2FlashLoanCallback is IAaveV2FlashLoanCallback {
         address pool = IAaveV2Provider(aaveV2Provider).getLendingPool();
 
         if (msg.sender != pool) revert InvalidCaller();
-        (, address agent) = IRouter(router).getUserAgent();
+        (, address agent) = IRouter(router).getCurrentUserAgent();
 
         // Transfer assets to the agent and record initial balances
         uint256 assetsLength = assets.length;

--- a/src/callbacks/AaveV3FlashLoanCallback.sol
+++ b/src/callbacks/AaveV3FlashLoanCallback.sol
@@ -42,7 +42,7 @@ contract AaveV3FlashLoanCallback is IAaveV3FlashLoanCallback {
         // Transfer assets to the agent and record initial balances
         uint256 assetsLength = assets.length;
         uint256[] memory initBalances = new uint256[](assetsLength);
-        for (uint256 i = 0; i < assetsLength; ) {
+        for (uint256 i; i < assetsLength; ) {
             address asset = assets[i];
 
             IERC20(asset).safeTransfer(agent, amounts[i]);
@@ -56,7 +56,7 @@ contract AaveV3FlashLoanCallback is IAaveV3FlashLoanCallback {
         agent.functionCall(abi.encodePacked(IAgent.execute.selector, params), 'ERROR_AAVE_V3_FLASH_LOAN_CALLBACK');
 
         // Approve assets for pulling from Aave Pool
-        for (uint256 i = 0; i < assetsLength; ) {
+        for (uint256 i; i < assetsLength; ) {
             address asset = assets[i];
             uint256 amountOwing = amounts[i] + premiums[i];
 

--- a/src/callbacks/AaveV3FlashLoanCallback.sol
+++ b/src/callbacks/AaveV3FlashLoanCallback.sol
@@ -37,7 +37,7 @@ contract AaveV3FlashLoanCallback is IAaveV3FlashLoanCallback {
         address pool = IAaveV3Provider(aaveV3Provider).getPool();
 
         if (msg.sender != pool) revert InvalidCaller();
-        (, address agent) = IRouter(router).getUserAgent();
+        (, address agent) = IRouter(router).getCurrentUserAgent();
 
         // Transfer assets to the agent and record initial balances
         uint256 assetsLength = assets.length;

--- a/src/callbacks/BalancerV2FlashLoanCallback.sol
+++ b/src/callbacks/BalancerV2FlashLoanCallback.sol
@@ -32,7 +32,7 @@ contract BalancerV2FlashLoanCallback is IBalancerV2FlashLoanCallback {
         // Transfer assets to the agent and record initial balances
         uint256 tokensLength = tokens.length;
         uint256[] memory initBalances = new uint256[](tokensLength);
-        for (uint256 i = 0; i < tokensLength; ) {
+        for (uint256 i; i < tokensLength; ) {
             address token = tokens[i];
 
             IERC20(token).safeTransfer(agent, amounts[i]);
@@ -49,7 +49,7 @@ contract BalancerV2FlashLoanCallback is IBalancerV2FlashLoanCallback {
         );
 
         // Repay tokens to Vault
-        for (uint256 i = 0; i < tokensLength; ) {
+        for (uint256 i; i < tokensLength; ) {
             address token = tokens[i];
             IERC20(token).safeTransfer(balancerV2Vault, amounts[i] + feeAmounts[i]);
 

--- a/src/callbacks/BalancerV2FlashLoanCallback.sol
+++ b/src/callbacks/BalancerV2FlashLoanCallback.sol
@@ -27,7 +27,7 @@ contract BalancerV2FlashLoanCallback is IBalancerV2FlashLoanCallback {
         bytes calldata userData
     ) external {
         if (msg.sender != balancerV2Vault) revert InvalidCaller();
-        (, address agent) = IRouter(router).getUserAgent();
+        (, address agent) = IRouter(router).getCurrentUserAgent();
 
         // Transfer assets to the agent and record initial balances
         uint256 tokensLength = tokens.length;

--- a/src/fees/AaveFlashLoanFeeCalculator.sol
+++ b/src/fees/AaveFlashLoanFeeCalculator.sol
@@ -87,7 +87,7 @@ contract AaveFlashLoanFeeCalculator is IFeeCalculator, FeeCalculatorBase {
     ) internal pure returns (IParam.Fee[] memory) {
         uint256 length = tokens.length;
         IParam.Fee[] memory fees = new IParam.Fee[](length);
-        for (uint256 i = 0; i < length; ) {
+        for (uint256 i; i < length; ) {
             fees[i] = IParam.Fee({token: tokens[i], amount: amounts[i], metadata: metadata});
 
             unchecked {
@@ -105,14 +105,14 @@ contract AaveFlashLoanFeeCalculator is IFeeCalculator, FeeCalculatorBase {
         uint256 length2 = fees2.length;
         IParam.Fee[] memory totalFees = new IParam.Fee[](length1 + length2);
 
-        for (uint256 i = 0; i < length1; ) {
+        for (uint256 i; i < length1; ) {
             totalFees[i] = fees1[i];
             unchecked {
                 ++i;
             }
         }
 
-        for (uint256 i = 0; i < length2; ) {
+        for (uint256 i; i < length2; ) {
             totalFees[length1 + i] = fees2[i];
             unchecked {
                 ++i;

--- a/src/fees/BalancerFlashLoanFeeCalculator.sol
+++ b/src/fees/BalancerFlashLoanFeeCalculator.sol
@@ -69,7 +69,7 @@ contract BalancerFlashLoanFeeCalculator is IFeeCalculator, FeeCalculatorBase {
     ) internal pure returns (IParam.Fee[] memory) {
         uint256 length = tokens.length;
         IParam.Fee[] memory fees = new IParam.Fee[](length);
-        for (uint256 i = 0; i < length; ) {
+        for (uint256 i; i < length; ) {
             fees[i] = IParam.Fee({token: tokens[i], amount: amounts[i], metadata: metadata});
 
             unchecked {
@@ -87,14 +87,14 @@ contract BalancerFlashLoanFeeCalculator is IFeeCalculator, FeeCalculatorBase {
         uint256 length2 = fees2.length;
         IParam.Fee[] memory totalFees = new IParam.Fee[](length1 + length2);
 
-        for (uint256 i = 0; i < length1; ) {
+        for (uint256 i; i < length1; ) {
             totalFees[i] = fees1[i];
             unchecked {
                 ++i;
             }
         }
 
-        for (uint256 i = 0; i < length2; ) {
+        for (uint256 i; i < length2; ) {
             totalFees[length1 + i] = fees2[i];
             unchecked {
                 ++i;

--- a/src/fees/BalancerFlashLoanFeeCalculator.sol
+++ b/src/fees/BalancerFlashLoanFeeCalculator.sol
@@ -12,9 +12,7 @@ contract BalancerFlashLoanFeeCalculator is IFeeCalculator, FeeCalculatorBase {
 
     constructor(address router_, uint256 feeRate_) FeeCalculatorBase(router_, feeRate_) {}
 
-    function getFees(address to, bytes calldata data) external view returns (IParam.Fee[] memory) {
-        to;
-
+    function getFees(address, bytes calldata data) external view returns (IParam.Fee[] memory) {
         // Balancer flash loan signature:'flashLoan(address,address[],uint256[],bytes)', selector: 0x5c38449e
         (, address[] memory tokens, uint256[] memory amounts, bytes memory userData) = abi.decode(
             data[4:],

--- a/src/fees/CompoundV3BorrowFeeCalculator.sol
+++ b/src/fees/CompoundV3BorrowFeeCalculator.sol
@@ -11,8 +11,7 @@ contract CompoundV3BorrowFeeCalculator is IFeeCalculator, FeeCalculatorBase {
 
     constructor(address router_, uint256 feeRate_) FeeCalculatorBase(router_, feeRate_) {}
 
-    function getFees(address to, bytes calldata data) external view returns (IParam.Fee[] memory) {
-        to;
+    function getFees(address, bytes calldata data) external view returns (IParam.Fee[] memory) {
         // Compound V3 borrow signature:'withdrawFrom(address,address,address,uint256)', selector:0x26441318
         (, , address asset, uint256 amount) = abi.decode(data[4:], (address, address, address, uint256));
 

--- a/src/fees/FeeCalculatorBase.sol
+++ b/src/fees/FeeCalculatorBase.sol
@@ -35,7 +35,7 @@ abstract contract FeeCalculatorBase {
     /// @param amounts An array of amounts with the fee included
     /// @return An array of calculated fees
     function calculateFee(uint256[] memory amounts) public view returns (uint256[] memory) {
-        for (uint256 i = 0; i < amounts.length; ) {
+        for (uint256 i; i < amounts.length; ) {
             amounts[i] = (amounts[i] * feeRate) / (_BPS_BASE + feeRate);
             unchecked {
                 ++i;
@@ -55,7 +55,7 @@ abstract contract FeeCalculatorBase {
     /// @param amounts An array of amounts to be calculated
     /// @return An array of the total amounts with the fees included
     function calculateAmountWithFee(uint256[] memory amounts) public view returns (uint256[] memory) {
-        for (uint256 i = 0; i < amounts.length; ) {
+        for (uint256 i; i < amounts.length; ) {
             amounts[i] = (amounts[i] * (_BPS_BASE + feeRate)) / _BPS_BASE;
             unchecked {
                 ++i;

--- a/src/fees/FeeGenerator.sol
+++ b/src/fees/FeeGenerator.sol
@@ -55,6 +55,32 @@ abstract contract FeeGenerator is Ownable {
         return logics;
     }
 
+    /// @notice Set fee calculator contracts
+    function setFeeCalculators(
+        bytes4[] calldata selectors,
+        address[] calldata tos,
+        address[] calldata feeCalculators_
+    ) external onlyOwner {
+        uint256 length = selectors.length;
+        if (length != tos.length) revert LengthMismatch();
+        if (length != feeCalculators_.length) revert LengthMismatch();
+
+        for (uint256 i; i < length; ) {
+            bytes4 selector = selectors[i];
+            address to = tos[i];
+            address feeCalculator = feeCalculators_[i];
+            setFeeCalculator(selector, to, feeCalculator);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    function setFeeCalculator(bytes4 selector, address to, address feeCalculator) public onlyOwner {
+        feeCalculators[selector][to] = feeCalculator;
+        emit FeeCalculatorSet(selector, to, feeCalculator);
+    }
+
     function getMsgValueWithFee(uint256 msgValue) public view returns (uint256) {
         IFeeCalculator nativeFeeCalculator = getNativeFeeCalculator();
         if (msgValue > 0 && address(nativeFeeCalculator) != address(0)) {
@@ -101,32 +127,6 @@ abstract contract FeeGenerator is Ownable {
         }
 
         return fees;
-    }
-
-    /// @notice Set fee calculator contracts
-    function setFeeCalculators(
-        bytes4[] calldata selectors,
-        address[] calldata tos,
-        address[] calldata feeCalculators_
-    ) external onlyOwner {
-        uint256 length = selectors.length;
-        if (length != tos.length) revert LengthMismatch();
-        if (length != feeCalculators_.length) revert LengthMismatch();
-
-        for (uint256 i; i < length; ) {
-            bytes4 selector = selectors[i];
-            address to = tos[i];
-            address feeCalculator = feeCalculators_[i];
-            setFeeCalculator(selector, to, feeCalculator);
-            unchecked {
-                ++i;
-            }
-        }
-    }
-
-    function setFeeCalculator(bytes4 selector, address to, address feeCalculator) public onlyOwner {
-        feeCalculators[selector][to] = feeCalculator;
-        emit FeeCalculatorSet(selector, to, feeCalculator);
     }
 
     function getFeeCalculator(bytes4 selector, address to) public view returns (address feeCalculator) {

--- a/src/fees/FeeGenerator.sol
+++ b/src/fees/FeeGenerator.sol
@@ -34,35 +34,9 @@ abstract contract FeeGenerator is Ownable {
         return (logics, msgValue);
     }
 
-    /// @notice Set fee calculator contracts
-    function setFeeCalculators(
-        bytes4[] calldata selectors,
-        address[] calldata tos,
-        address[] calldata feeCalculators_
-    ) external onlyOwner {
-        uint256 length = selectors.length;
-        if (length != tos.length) revert LengthMismatch();
-        if (length != feeCalculators_.length) revert LengthMismatch();
-
-        for (uint256 i = 0; i < length; ) {
-            bytes4 selector = selectors[i];
-            address to = tos[i];
-            address feeCalculator = feeCalculators_[i];
-            setFeeCalculator(selector, to, feeCalculator);
-            unchecked {
-                ++i;
-            }
-        }
-    }
-
-    function setFeeCalculator(bytes4 selector, address to, address feeCalculator) public onlyOwner {
-        feeCalculators[selector][to] = feeCalculator;
-        emit FeeCalculatorSet(selector, to, feeCalculator);
-    }
-
     function getLogicsDataWithFee(IParam.Logic[] memory logics) public view returns (IParam.Logic[] memory) {
         uint256 length = logics.length;
-        for (uint256 i = 0; i < length; ) {
+        for (uint256 i; i < length; ) {
             bytes memory data = logics[i].data;
             bytes4 selector = bytes4(data);
             address to = logics[i].to;
@@ -93,7 +67,7 @@ abstract contract FeeGenerator is Ownable {
         IParam.Fee[] memory tempFees = new IParam.Fee[](32); // Create a temporary `tempFees` with size 32 to store fee
         uint256 realFeeLength;
         uint256 logicsLength = logics.length;
-        for (uint256 i = 0; i < logicsLength; ++i) {
+        for (uint256 i; i < logicsLength; ++i) {
             bytes memory data = logics[i].data;
             bytes4 selector = bytes4(data);
             address to = logics[i].to;
@@ -122,11 +96,37 @@ abstract contract FeeGenerator is Ownable {
 
         // Copy tempFees to fees
         IParam.Fee[] memory fees = new IParam.Fee[](realFeeLength);
-        for (uint256 i = 0; i < realFeeLength; ++i) {
+        for (uint256 i; i < realFeeLength; ++i) {
             fees[i] = tempFees[i];
         }
 
         return fees;
+    }
+
+    /// @notice Set fee calculator contracts
+    function setFeeCalculators(
+        bytes4[] calldata selectors,
+        address[] calldata tos,
+        address[] calldata feeCalculators_
+    ) external onlyOwner {
+        uint256 length = selectors.length;
+        if (length != tos.length) revert LengthMismatch();
+        if (length != feeCalculators_.length) revert LengthMismatch();
+
+        for (uint256 i; i < length; ) {
+            bytes4 selector = selectors[i];
+            address to = tos[i];
+            address feeCalculator = feeCalculators_[i];
+            setFeeCalculator(selector, to, feeCalculator);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    function setFeeCalculator(bytes4 selector, address to, address feeCalculator) public onlyOwner {
+        feeCalculators[selector][to] = feeCalculator;
+        emit FeeCalculatorSet(selector, to, feeCalculator);
     }
 
     function getFeeCalculator(bytes4 selector, address to) public view returns (address feeCalculator) {

--- a/src/fees/FeeGenerator.sol
+++ b/src/fees/FeeGenerator.sol
@@ -34,27 +34,6 @@ abstract contract FeeGenerator is Ownable {
         return (logics, msgValue);
     }
 
-    function getLogicsDataWithFee(IParam.Logic[] memory logics) public view returns (IParam.Logic[] memory) {
-        uint256 length = logics.length;
-        for (uint256 i; i < length; ) {
-            bytes memory data = logics[i].data;
-            bytes4 selector = bytes4(data);
-            address to = logics[i].to;
-            address feeCalculator = getFeeCalculator(selector, to);
-
-            // Get transaction data with fee
-            if (feeCalculator != address(0)) {
-                logics[i].data = IFeeCalculator(feeCalculator).getDataWithFee(data);
-            }
-
-            unchecked {
-                ++i;
-            }
-        }
-
-        return logics;
-    }
-
     /// @notice Set fee calculator contracts
     function setFeeCalculators(
         bytes4[] calldata selectors,
@@ -79,6 +58,27 @@ abstract contract FeeGenerator is Ownable {
     function setFeeCalculator(bytes4 selector, address to, address feeCalculator) public onlyOwner {
         feeCalculators[selector][to] = feeCalculator;
         emit FeeCalculatorSet(selector, to, feeCalculator);
+    }
+
+    function getLogicsDataWithFee(IParam.Logic[] memory logics) public view returns (IParam.Logic[] memory) {
+        uint256 length = logics.length;
+        for (uint256 i; i < length; ) {
+            bytes memory data = logics[i].data;
+            bytes4 selector = bytes4(data);
+            address to = logics[i].to;
+            address feeCalculator = getFeeCalculator(selector, to);
+
+            // Get transaction data with fee
+            if (feeCalculator != address(0)) {
+                logics[i].data = IFeeCalculator(feeCalculator).getDataWithFee(data);
+            }
+
+            unchecked {
+                ++i;
+            }
+        }
+
+        return logics;
     }
 
     function getMsgValueWithFee(uint256 msgValue) public view returns (uint256) {

--- a/src/fees/MakerDrawFeeCalculator.sol
+++ b/src/fees/MakerDrawFeeCalculator.sol
@@ -15,7 +15,7 @@ contract MakerDrawFeeCalculator is IFeeCalculator, FeeCalculatorBase {
     uint256 internal constant _DRAW_DATA_START_INDEX = 104;
     uint256 internal constant _DRAW_DATA_END_INDEX = 264;
 
-    address public daiToken;
+    address public immutable daiToken;
 
     constructor(address router_, uint256 feeRate_, address daiToken_) FeeCalculatorBase(router_, feeRate_) {
         daiToken = daiToken_;

--- a/src/fees/MakerDrawFeeCalculator.sol
+++ b/src/fees/MakerDrawFeeCalculator.sol
@@ -21,9 +21,7 @@ contract MakerDrawFeeCalculator is IFeeCalculator, FeeCalculatorBase {
         daiToken = daiToken_;
     }
 
-    function getFees(address to, bytes calldata data) external view returns (IParam.Fee[] memory) {
-        to;
-
+    function getFees(address, bytes calldata data) external view returns (IParam.Fee[] memory) {
         // DSProxy execute signature:'execute(address,bytes)', selector:0x1cff79cd
         // Maker draw signature:'draw(address,address,address,uint256,uint256)', selector:0x9f6f3d5b
 

--- a/src/fees/NativeFeeCalculator.sol
+++ b/src/fees/NativeFeeCalculator.sol
@@ -12,9 +12,7 @@ contract NativeFeeCalculator is IFeeCalculator, FeeCalculatorBase {
 
     constructor(address router_, uint256 feeRate_) FeeCalculatorBase(router_, feeRate_) {}
 
-    function getFees(address to, bytes calldata data) external view returns (IParam.Fee[] memory) {
-        to;
-
+    function getFees(address, bytes calldata data) external view returns (IParam.Fee[] memory) {
         IParam.Fee[] memory fees = new IParam.Fee[](1);
         fees[0] = IParam.Fee({token: _NATIVE, amount: calculateFee(uint256(bytes32(data))), metadata: _META_DATA});
         return fees;

--- a/src/fees/Permit2FeeCalculator.sol
+++ b/src/fees/Permit2FeeCalculator.sol
@@ -11,9 +11,7 @@ contract Permit2FeeCalculator is IFeeCalculator, FeeCalculatorBase {
 
     constructor(address router_, uint256 feeRate_) FeeCalculatorBase(router_, feeRate_) {}
 
-    function getFees(address to, bytes calldata data) external view returns (IParam.Fee[] memory) {
-        to;
-
+    function getFees(address, bytes calldata data) external view returns (IParam.Fee[] memory) {
         // Permit2 transfrom signature:'transferFrom(address,address,uint160,address)', selector:0x36c78516
         (, , uint160 amount, address token) = abi.decode(data[4:], (address, address, uint160, address));
 

--- a/src/interfaces/IRouter.sol
+++ b/src/interfaces/IRouter.sol
@@ -59,7 +59,7 @@ interface IRouter {
 
     function getAgent(address user) external view returns (address);
 
-    function getUserAgent() external view returns (address, address);
+    function getCurrentUserAgent() external view returns (address, address);
 
     function calcAgent(address user) external view returns (address);
 

--- a/src/interfaces/IRouter.sol
+++ b/src/interfaces/IRouter.sol
@@ -75,7 +75,7 @@ interface IRouter {
 
     function pause() external;
 
-    function resume() external;
+    function unpause() external;
 
     function execute(
         IParam.Logic[] calldata logics,

--- a/src/interfaces/IRouter.sol
+++ b/src/interfaces/IRouter.sol
@@ -15,7 +15,7 @@ interface IRouter {
 
     event Paused();
 
-    event Resumed();
+    event Unpaused();
 
     event Execute(address indexed user, address indexed agent, uint256 indexed referralCode);
 

--- a/src/libraries/LogicHash.sol
+++ b/src/libraries/LogicHash.sol
@@ -33,7 +33,7 @@ library LogicHash {
         uint256 inputsLength = inputs.length;
         bytes32[] memory inputHashes = new bytes32[](inputsLength);
 
-        for (uint256 i = 0; i < inputsLength; ) {
+        for (uint256 i; i < inputsLength; ) {
             inputHashes[i] = _hash(inputs[i]);
             unchecked {
                 ++i;
@@ -62,14 +62,14 @@ library LogicHash {
         bytes32[] memory logicHashes = new bytes32[](logicsLength);
         bytes32[] memory feeHashes = new bytes32[](feesLength);
 
-        for (uint256 i = 0; i < logicsLength; ) {
+        for (uint256 i; i < logicsLength; ) {
             logicHashes[i] = _hash(logics[i]);
             unchecked {
                 ++i;
             }
         }
 
-        for (uint256 i = 0; i < feesLength; ) {
+        for (uint256 i; i < feesLength; ) {
             feeHashes[i] = _hash(fees[i]);
             unchecked {
                 ++i;

--- a/src/utilities/MakerUtility.sol
+++ b/src/utilities/MakerUtility.sol
@@ -50,7 +50,7 @@ contract MakerUtility is IMakerUtility {
         bytes32 ilk,
         uint256 wadD
     ) external payable returns (uint256 cdp) {
-        (address user, address agent) = IRouter(router).getUserAgent();
+        (address user, address agent) = IRouter(router).getCurrentUserAgent();
         if (msg.sender != agent) revert InvalidAgent();
 
         bytes32 ret = dsProxy.execute{value: value}(
@@ -80,7 +80,7 @@ contract MakerUtility is IMakerUtility {
         uint256 wadC,
         uint256 wadD
     ) external returns (uint256 cdp) {
-        (address user, address agent) = IRouter(router).getUserAgent();
+        (address user, address agent) = IRouter(router).getCurrentUserAgent();
         if (msg.sender != agent) revert InvalidAgent();
 
         // Get collateral token

--- a/test/Router.t.sol
+++ b/test/Router.t.sol
@@ -147,13 +147,13 @@ contract RouterTest is Test, LogicSignature {
         );
         vm.prank(user);
         router.execute(logics, tokensReturnEmpty, SIGNER_REFERRAL);
-        (, agent) = router.getUserAgent();
+        (, agent) = router.getCurrentUserAgent();
         // The executing agent should be reset to 0
         assertEq(agent, address(0));
     }
 
     function checkExecutingAgent(address agent) external view {
-        (, address executingAgent) = router.getUserAgent();
+        (, address executingAgent) = router.getCurrentUserAgent();
         if (agent != executingAgent) revert();
     }
 

--- a/test/Router.t.sol
+++ b/test/Router.t.sol
@@ -34,7 +34,7 @@ contract RouterTest is Test, LogicSignature {
     event SignerRemoved(address indexed signer);
     event PauserSet(address indexed pauser);
     event Paused();
-    event Resumed();
+    event Unpaused();
     event AgentCreated(address indexed agent, address indexed user);
     event Execute(address indexed user, address indexed agent, uint256 indexed referralCode);
 
@@ -227,7 +227,7 @@ contract RouterTest is Test, LogicSignature {
         vm.prank(user);
         router.execute(logicsEmpty, tokensReturnEmpty, SIGNER_REFERRAL);
 
-        // Execution success when router resumed
+        // Execution success when router unpaused
         vm.prank(pauser);
         router.resume();
         assertFalse(router.paused());
@@ -312,19 +312,19 @@ contract RouterTest is Test, LogicSignature {
         router.pause();
     }
 
-    function testResume() external {
+    function testUnpause() external {
         vm.prank(pauser);
         router.pause();
         assertTrue(router.paused());
 
         vm.expectEmit(true, true, true, true, address(router));
-        emit Resumed();
+        emit Unpaused();
         vm.prank(pauser);
         router.resume();
         assertFalse(router.paused());
     }
 
-    function testCannotResumeByNonPauser() external {
+    function testCannotUnpauseByNonPauser() external {
         vm.prank(pauser);
         router.pause();
         assertTrue(router.paused());

--- a/test/Router.t.sol
+++ b/test/Router.t.sol
@@ -229,7 +229,7 @@ contract RouterTest is Test, LogicSignature {
 
         // Execution success when router unpaused
         vm.prank(pauser);
-        router.resume();
+        router.unpause();
         assertFalse(router.paused());
         router.execute(logicsEmpty, tokensReturnEmpty, SIGNER_REFERRAL);
     }
@@ -320,7 +320,7 @@ contract RouterTest is Test, LogicSignature {
         vm.expectEmit(true, true, true, true, address(router));
         emit Unpaused();
         vm.prank(pauser);
-        router.resume();
+        router.unpause();
         assertFalse(router.paused());
     }
 
@@ -331,7 +331,7 @@ contract RouterTest is Test, LogicSignature {
 
         vm.expectRevert(IRouter.InvalidPauser.selector);
         vm.prank(user);
-        router.resume();
+        router.unpause();
     }
 
     function testRescue(uint256 amount) external {

--- a/test/callbacks/AaveV2FlashLoanCallback.t.sol
+++ b/test/callbacks/AaveV2FlashLoanCallback.t.sol
@@ -34,7 +34,7 @@ contract AaveV2FlashLoanCallbackTest is Test {
         mockERC20 = new ERC20('mockERC20', 'mock');
 
         // Return activated agent from router
-        vm.mockCall(router, 0, abi.encodeWithSignature('getUserAgent()'), abi.encode(user, agent));
+        vm.mockCall(router, 0, abi.encodeWithSignature('getCurrentUserAgent()'), abi.encode(user, agent));
         vm.label(address(flashLoanCallback), 'AaveV2FlashLoanCallback');
         vm.label(address(aaveV2Provider), 'AaveV2Provider');
         vm.label(address(mockERC20), 'mERC20');

--- a/test/callbacks/AaveV3FlashLoanCallback.t.sol
+++ b/test/callbacks/AaveV3FlashLoanCallback.t.sol
@@ -34,7 +34,7 @@ contract AaveV3FlashLoanCallbackTest is Test {
         mockERC20 = new ERC20('mockERC20', 'mock');
 
         // Return activated agent from router
-        vm.mockCall(router, 0, abi.encodeWithSignature('getUserAgent()'), abi.encode(user, agent));
+        vm.mockCall(router, 0, abi.encodeWithSignature('getCurrentUserAgent()'), abi.encode(user, agent));
         vm.label(address(flashLoanCallback), 'AaveV3FlashLoanCallback');
         vm.label(address(aaveV3Provider), 'AaveV3Provider');
         vm.label(address(mockERC20), 'mERC20');

--- a/test/callbacks/BalancerV2FlashLoanCallback.t.sol
+++ b/test/callbacks/BalancerV2FlashLoanCallback.t.sol
@@ -34,7 +34,7 @@ contract BalancerV2FlashLoanCallbackTest is Test {
         mockERC20 = new ERC20('mockERC20', 'mock');
 
         // Return activated agent from router
-        vm.mockCall(router, 0, abi.encodeWithSignature('getUserAgent()'), abi.encode(user, agent));
+        vm.mockCall(router, 0, abi.encodeWithSignature('getCurrentUserAgent()'), abi.encode(user, agent));
         vm.label(address(flashLoanCallback), 'BalancerV2FlashLoanCallback');
         vm.label(BALANCER_V2_VAULT, 'BalancerV2Vault');
         vm.label(address(mockERC20), 'mERC20');


### PR DESCRIPTION
- For loop variable doesn't need to set to zero
- The opposite meaning isPaused modifier is whenNotPaused
- WrappedNative doesn't need to convert to address type
- Replace the `address to` with `address` if it is unused in calculator.getFees()
- Set daiToken of MakerDrawFeeCalculator to immutable
- add _newAgent(address user) internal function to save gas cost in execute/executeWithSignature
- Unnecessary uint160 casting when calculating agent address
- Rename  getUserAgent() to getCurrentUserAgent()