### PR TITLE
Fix the execution order of charge and unwrap in _executeLogics

### DIFF
--- a/src/AgentImplementation.sol
+++ b/src/AgentImplementation.sol
@@ -216,6 +216,7 @@ contract AgentImplementation is IAgent, ERC721Holder, ERC1155Holder {
             // Revert if the previous call didn't enter `executeByCallback`
             if (_callbackWithCharge != _INIT_CALLBACK_WITH_CHARGE) revert UnresetCallbackWithCharge();
 
+            // Charge fee before unwrap to prevent insufficient wrapped native
             if (shouldChargeFeeByLogic) {
                 _chargeFeeByLogic(logics[i]);
             }

--- a/src/AgentImplementation.sol
+++ b/src/AgentImplementation.sol
@@ -216,13 +216,13 @@ contract AgentImplementation is IAgent, ERC721Holder, ERC1155Holder {
             // Revert if the previous call didn't enter `executeByCallback`
             if (_callbackWithCharge != _INIT_CALLBACK_WITH_CHARGE) revert UnresetCallbackWithCharge();
 
+            if (shouldChargeFeeByLogic) {
+                _chargeFeeByLogic(logics[i]);
+            }
+
             // Unwrap to native after the call
             if (wrapMode == IParam.WrapMode.UNWRAP_AFTER) {
                 IWrappedNative(wrappedNative).withdraw(_getBalance(wrappedNative) - wrappedAmount);
-            }
-
-            if (shouldChargeFeeByLogic) {
-                _chargeFeeByLogic(logics[i]);
             }
 
             unchecked {


### PR DESCRIPTION
In the current implementation of AgentImplementation::_executeLogics, the process ends symmetrically by first handling unwrap, then charging the fee.

However, this order presents the same issue we initially encountered https://github.com/dinngo/composable-router-contract/pull/72 which behaves similarly to a 100% chained input, followed by a charge fee operation which fails to retrieve the fee, causing the transaction to fail.

This scenario is likely to occur. For example, consider a feature that offers borrow ether and a borrow fee calculator exists. It encodes with borrow weth + unwrap flag. Since we charge a weth fee at this point, the amount of unwrap should exclude the fee amount.