### PR TITLE
Use currentUser as paused state for reducing cold read gas cost

### DIFF
--- a/src/Router.sol
+++ b/src/Router.sol
@@ -139,7 +139,7 @@ contract Router is IRouter, EIP712, FeeGenerator {
 
     /// @notice Pause `execute` and `executeWithSignature` by pauser
     function pause() external onlyPauser {
-        if (currentUser != _INIT_CURRENT_USER) revert AlreadyPaused();
+        if (currentUser == _PAUSED) revert AlreadyPaused();
         currentUser = _PAUSED;
         emit Paused();
     }

--- a/src/Router.sol
+++ b/src/Router.sol
@@ -41,8 +41,8 @@ contract Router is IRouter, EIP712, FeeGenerator {
     /// @notice Address for invoking pause
     address public pauser;
 
-    modifier onlyInitCurrentUser() {
-        if (currentUser != _INIT_CURRENT_USER) revert NotInitCurrentUser();
+    modifier whenReady() {
+        if (currentUser != _INIT_CURRENT_USER) revert NotReady();
         currentUser = msg.sender;
         _;
         currentUser = _INIT_CURRENT_USER;
@@ -161,7 +161,7 @@ contract Router is IRouter, EIP712, FeeGenerator {
         IParam.Logic[] calldata logics,
         address[] calldata tokensReturn,
         uint256 referralCode
-    ) external payable onlyInitCurrentUser {
+    ) external payable whenReady {
         address user = currentUser;
         IAgent agent = agents[user];
 
@@ -187,7 +187,7 @@ contract Router is IRouter, EIP712, FeeGenerator {
         bytes calldata signature,
         address[] calldata tokensReturn,
         uint256 referralCode
-    ) external payable onlyInitCurrentUser {
+    ) external payable whenReady {
         // Verify deadline, signer and signature
         uint256 deadline = logicBatch.deadline;
         if (block.timestamp > deadline) revert SignatureExpired(deadline);

--- a/src/interfaces/IRouter.sol
+++ b/src/interfaces/IRouter.sol
@@ -21,11 +21,13 @@ interface IRouter {
 
     event AgentCreated(address indexed agent, address indexed user);
 
-    error Reentrancy();
-
-    error RouterIsPaused();
+    error NotInitCurrentUser();
 
     error InvalidPauser();
+
+    error AlreadyPaused();
+
+    error NotPaused();
 
     error InvalidFeeCollector();
 
@@ -50,8 +52,6 @@ interface IRouter {
     function feeCollector() external view returns (address);
 
     function pauser() external view returns (address);
-
-    function paused() external view returns (bool);
 
     function owner() external view returns (address);
 

--- a/src/interfaces/IRouter.sol
+++ b/src/interfaces/IRouter.sol
@@ -21,7 +21,7 @@ interface IRouter {
 
     event AgentCreated(address indexed agent, address indexed user);
 
-    error NotInitCurrentUser();
+    error NotReady();
 
     error InvalidPauser();
 

--- a/test/Router.t.sol
+++ b/test/Router.t.sol
@@ -219,11 +219,11 @@ contract RouterTest is Test, LogicSignature {
 
         vm.startPrank(user);
         // `execute` should revert when router is paused
-        vm.expectRevert(IRouter.NotInitCurrentUser.selector);
+        vm.expectRevert(IRouter.NotReady.selector);
         router.execute(logicsEmpty, tokensReturnEmpty, SIGNER_REFERRAL);
 
         // `executeWithSignature` should revert when router is paused
-        vm.expectRevert(IRouter.NotInitCurrentUser.selector);
+        vm.expectRevert(IRouter.NotReady.selector);
         router.executeWithSignature(logicBatchEmpty, signer, new bytes(0), tokensReturnEmpty, SIGNER_REFERRAL);
         vm.stopPrank();
     }
@@ -238,7 +238,7 @@ contract RouterTest is Test, LogicSignature {
             address(0), // approveTo
             address(0) // callback
         );
-        vm.expectRevert(IRouter.NotInitCurrentUser.selector);
+        vm.expectRevert(IRouter.NotReady.selector);
         vm.prank(user);
         router.execute(logics, tokensReturnEmpty, SIGNER_REFERRAL);
     }

--- a/test/Router.t.sol
+++ b/test/Router.t.sol
@@ -344,7 +344,7 @@ contract RouterTest is Test, LogicSignature {
         router.unpause();
     }
 
-    function testCannotPauseWhenNotPaused() external {
+    function testCannotUnpauseWhenNotPaused() external {
         vm.expectRevert(IRouter.NotPaused.selector);
         vm.prank(pauser);
         router.unpause();

--- a/test/invariants/RouterInvariants.t.sol
+++ b/test/invariants/RouterInvariants.t.sol
@@ -6,7 +6,7 @@ import {Router} from 'src/Router.sol';
 import {RouterHandler} from './handlers/RouterHandler.sol';
 
 contract RouterInvariantsTest is Test {
-    address internal constant _INIT_USER = address(1);
+    address internal constant _INIT_CURRENT_USER = address(1);
 
     Router public router;
     RouterHandler public handler;
@@ -28,7 +28,7 @@ contract RouterInvariantsTest is Test {
     }
 
     function invariant_initializedCurrentUser() external {
-        assertEq(router.currentUser(), _INIT_USER);
+        assertEq(router.currentUser(), _INIT_CURRENT_USER);
     }
 
     function invariant_matchedAgentsLength() external {


### PR DESCRIPTION
- [x] Reduce ~2300 gas for every execution by removing `paused` storage
- [x] Rename `_INIT_USER` to `_INIT_CURRENT_USER`
- [x] Simplify router's `execute*` modifiers with `onlyInitCurrentUser`
- [x] Add state checks for `pause` and `unpause` functions