### PR TITLE
Refactor bps and offset flags, and comment in AgentImplementation

### DIFF
--- a/src/interfaces/IParam.sol
+++ b/src/interfaces/IParam.sol
@@ -22,8 +22,8 @@ interface IParam {
     /// @notice Input represents a single input for token amount calculation and approval
     struct Input {
         address token; // Token address
-        uint256 balanceBps; // Basis points for calculating the amount, set to _SKIP to use amountOrOffset as amount
-        uint256 amountOrOffset; // Read as amount if balanceBps is _SKIP; otherwise, read as byte offset of amount in Logic.data for replacement
+        uint256 balanceBps; // Basis points for calculating the amount, set 0 to use amountOrOffset as amount
+        uint256 amountOrOffset; // Read as amount if balanceBps is 0; otherwise, read as byte offset of amount in `Logic.data` for replacement, or set 1 << 255 for no replacement
     }
 
     /// @notice Fee represents a fee to be charged

--- a/test/Router.t.sol
+++ b/test/Router.t.sol
@@ -14,7 +14,7 @@ contract RouterTest is Test, LogicSignature {
 
     address public constant PAUSED = address(0);
     address public constant INIT_CURRENT_USER = address(1);
-    uint256 public constant SKIP = 0x8000000000000000000000000000000000000000000000000000000000000000;
+    uint256 public constant BPS_NOT_USED = 0;
     uint256 public constant SIGNER_REFERRAL = 1;
     address public constant INVALID_PAUSER = address(0);
 
@@ -187,7 +187,7 @@ contract RouterTest is Test, LogicSignature {
         IParam.Input[] memory inputs = new IParam.Input[](1);
         inputs[0] = IParam.Input(
             address(mockERC20),
-            SKIP, // balanceBps
+            BPS_NOT_USED, // balanceBps
             0 // amountOrOffset
         );
         IParam.Logic[] memory logics = new IParam.Logic[](1);

--- a/test/fees/AaveFlashLoanFeeCalculator.t.sol
+++ b/test/fees/AaveFlashLoanFeeCalculator.t.sol
@@ -46,7 +46,7 @@ contract AaveFlashLoanFeeCalculatorTest is Test, ERC20Permit2Utils {
     bytes4 public constant PERMIT2_TRANSFER_FROM_SELECTOR =
         bytes4(keccak256(bytes('transferFrom(address,address,uint160,address)')));
     bytes4 public constant NATIVE_FEE_SELECTOR = 0xeeeeeeee;
-    uint256 public constant SKIP = 0x8000000000000000000000000000000000000000000000000000000000000000;
+    uint256 public constant BPS_NOT_USED = 0;
     uint256 public constant BPS_BASE = 10_000;
     bytes32 public constant V2_FLASHLOAN_META_DATA = bytes32(bytes('aave-v2:flash-loan'));
     bytes32 public constant V3_FLASHLOAN_META_DATA = bytes32(bytes('aave-v3:flash-loan'));
@@ -455,7 +455,7 @@ contract AaveFlashLoanFeeCalculatorTest is Test, ERC20Permit2Utils {
         // Encode inputs
         IParam.Input[] memory inputs = new IParam.Input[](1);
         inputs[0].token = NATIVE;
-        inputs[0].balanceBps = SKIP;
+        inputs[0].balanceBps = BPS_NOT_USED;
         inputs[0].amountOrOffset = amount;
 
         return

--- a/test/fees/BalancerFlashLoanFeeCalculator.t.sol
+++ b/test/fees/BalancerFlashLoanFeeCalculator.t.sol
@@ -30,7 +30,7 @@ contract BalancerFlashLoanFeeCalculatorTest is Test, ERC20Permit2Utils {
     bytes4 public constant PERMIT2_TRANSFER_FROM_SELECTOR =
         bytes4(keccak256(bytes('transferFrom(address,address,uint160,address)')));
     bytes4 public constant NATIVE_FEE_SELECTOR = 0xeeeeeeee;
-    uint256 public constant SKIP = 0x8000000000000000000000000000000000000000000000000000000000000000;
+    uint256 public constant BPS_NOT_USED = 0;
     uint256 public constant BPS_BASE = 10_000;
     bytes32 public constant BALANCER_META_DATA = bytes32(bytes('balancer-v2:flash-loan'));
     bytes32 public constant NATIVE_TOKEN_META_DATA = bytes32(bytes('native-token'));
@@ -356,7 +356,7 @@ contract BalancerFlashLoanFeeCalculatorTest is Test, ERC20Permit2Utils {
         // Encode inputs
         IParam.Input[] memory inputs = new IParam.Input[](1);
         inputs[0].token = NATIVE;
-        inputs[0].balanceBps = SKIP;
+        inputs[0].balanceBps = BPS_NOT_USED;
         inputs[0].amountOrOffset = amount;
 
         return

--- a/test/fees/FeeGeneralCases.t.sol
+++ b/test/fees/FeeGeneralCases.t.sol
@@ -30,7 +30,7 @@ contract FeeGeneralCasesTest is Test {
     bytes4 public constant AAVE_FLASHLOAN_SELECTOR =
         bytes4(keccak256(bytes('flashLoan(address,address[],uint256[],uint256[],address,bytes,uint16)')));
     bytes4 public constant NATIVE_FEE_SELECTOR = 0xeeeeeeee;
-    uint256 public constant SKIP = 0x8000000000000000000000000000000000000000000000000000000000000000;
+    uint256 public constant BPS_NOT_USED = 0;
     uint256 public constant BPS_BASE = 10_000;
     uint256 public constant SIGNER_REFERRAL = 1;
     uint256 public constant FEE_RATE = 20;
@@ -250,7 +250,7 @@ contract FeeGeneralCasesTest is Test {
         // Encode inputs
         IParam.Input[] memory inputs = new IParam.Input[](1);
         inputs[0].token = NATIVE;
-        inputs[0].balanceBps = SKIP;
+        inputs[0].balanceBps = BPS_NOT_USED;
         inputs[0].amountOrOffset = amount;
 
         return

--- a/test/fees/NativeFeeCalculator.t.sol
+++ b/test/fees/NativeFeeCalculator.t.sol
@@ -15,7 +15,7 @@ contract NativeFeeCalculatorTest is Test {
     address public constant ANY_TO_ADDRESS = address(0);
     bytes4 public constant NATIVE_FEE_SELECTOR = 0xeeeeeeee;
     bytes public constant EMPTY_LOGIC_DATA = new bytes(0);
-    uint256 public constant SKIP = 0x8000000000000000000000000000000000000000000000000000000000000000;
+    uint256 public constant BPS_NOT_USED = 0;
     uint256 public constant SIGNER_REFERRAL = 1;
     uint256 public constant BPS_BASE = 10_000;
     bytes32 public constant META_DATA = bytes32(bytes('native-token'));
@@ -98,7 +98,7 @@ contract NativeFeeCalculatorTest is Test {
         // Encode inputs
         IParam.Input[] memory inputs = new IParam.Input[](1);
         inputs[0].token = NATIVE;
-        inputs[0].balanceBps = SKIP;
+        inputs[0].balanceBps = BPS_NOT_USED;
         inputs[0].amountOrOffset = amount;
 
         return

--- a/test/integration/ERC1155Market.t.sol
+++ b/test/integration/ERC1155Market.t.sol
@@ -18,7 +18,7 @@ contract ERC1155MarketTest is Test, ERC20Permit2Utils, ERC1155Utils {
 
     IERC20 public constant USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
     uint256 public constant BPS_BASE = 10_000;
-    uint256 public constant SKIP = 0x8000000000000000000000000000000000000000000000000000000000000000;
+    uint256 public constant BPS_NOT_USED = 0;
 
     address public user;
     uint256 public userPrivateKey;
@@ -192,7 +192,7 @@ contract ERC1155MarketTest is Test, ERC20Permit2Utils, ERC1155Utils {
         // Encode inputs
         IParam.Input[] memory inputs = new IParam.Input[](1);
         inputs[0].token = address(tokenIn);
-        inputs[0].balanceBps = SKIP;
+        inputs[0].balanceBps = BPS_NOT_USED;
         inputs[0].amountOrOffset = amountIn;
 
         return
@@ -223,7 +223,7 @@ contract ERC1155MarketTest is Test, ERC20Permit2Utils, ERC1155Utils {
         // Encode inputs
         IParam.Input[] memory inputs = new IParam.Input[](1);
         inputs[0].token = address(tokenIn);
-        inputs[0].balanceBps = SKIP;
+        inputs[0].balanceBps = BPS_NOT_USED;
         inputs[0].amountOrOffset = amountIn;
 
         return

--- a/test/integration/ERC721Market.t.sol
+++ b/test/integration/ERC721Market.t.sol
@@ -18,7 +18,7 @@ contract ERC721MarketTest is Test, ERC20Permit2Utils, ERC721Utils {
 
     IERC20 public constant USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
     uint256 public constant BPS_BASE = 10_000;
-    uint256 public constant SKIP = 0x8000000000000000000000000000000000000000000000000000000000000000;
+    uint256 public constant BPS_NOT_USED = 0;
 
     address public user;
     uint256 public userPrivateKey;
@@ -133,7 +133,7 @@ contract ERC721MarketTest is Test, ERC20Permit2Utils, ERC721Utils {
         // Encode inputs
         IParam.Input[] memory inputs = new IParam.Input[](1);
         inputs[0].token = address(tokenIn);
-        inputs[0].balanceBps = SKIP;
+        inputs[0].balanceBps = BPS_NOT_USED;
         inputs[0].amountOrOffset = amountIn;
 
         return

--- a/test/integration/UniswapV2.t.sol
+++ b/test/integration/UniswapV2.t.sol
@@ -59,7 +59,7 @@ contract UniswapV2Test is Test, ERC20Permit2Utils {
     IERC20 public constant USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
     IUniswapV2Router02 public constant uniswapRouter02 = IUniswapV2Router02(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);
     uint256 public constant BPS_BASE = 10_000;
-    uint256 public constant SKIP = 0x8000000000000000000000000000000000000000000000000000000000000000;
+    uint256 public constant BPS_NOT_USED = 0;
 
     address public user;
     uint256 public userPrivateKey;
@@ -102,7 +102,7 @@ contract UniswapV2Test is Test, ERC20Permit2Utils {
 
         // Encode logics
         IParam.Logic[] memory logics = new IParam.Logic[](1);
-        logics[0] = _logicUniswapV2Swap(tokenIn, amountIn, SKIP, tokenOut, IParam.WrapMode.WRAP_BEFORE); // Fixed amount
+        logics[0] = _logicUniswapV2Swap(tokenIn, amountIn, BPS_NOT_USED, tokenOut, IParam.WrapMode.WRAP_BEFORE); // Fixed amount
 
         // Execute
         address[] memory tokensReturn = new address[](1);
@@ -129,7 +129,7 @@ contract UniswapV2Test is Test, ERC20Permit2Utils {
         // Encode logics
         IParam.Logic[] memory logics = new IParam.Logic[](2);
         logics[0] = logicERC20Permit2PullToken(tokenIn, amountIn.toUint160());
-        logics[1] = _logicUniswapV2Swap(tokenIn, amountIn, SKIP, tokenOut, IParam.WrapMode.UNWRAP_AFTER); // Fixed amount
+        logics[1] = _logicUniswapV2Swap(tokenIn, amountIn, BPS_NOT_USED, tokenOut, IParam.WrapMode.UNWRAP_AFTER); // Fixed amount
 
         // Execute
         address[] memory tokensReturn = new address[](1);
@@ -223,7 +223,7 @@ contract UniswapV2Test is Test, ERC20Permit2Utils {
         uint256 amountMin = (amountsOut[1] * 9_900) / BPS_BASE;
         bytes memory data = abi.encodeWithSelector(
             uniswapRouter02.swapExactTokensForTokens.selector,
-            (balanceBps == SKIP) ? amountIn : 0, // 0 is the amount which will be repalced
+            (balanceBps == BPS_NOT_USED) ? amountIn : 0, // 0 is the amount which will be replaced
             amountMin, // amountOutMin
             path, // path
             address(agent), // to
@@ -235,7 +235,7 @@ contract UniswapV2Test is Test, ERC20Permit2Utils {
         inputs[0] = IParam.Input(
             address(tokenIn),
             balanceBps,
-            (balanceBps == SKIP) ? amountIn : 0x0 // 0x0 is the amount offset in data
+            (balanceBps == BPS_NOT_USED) ? amountIn : 0x0 // 0x0 is the amount offset in data
         );
 
         return
@@ -277,9 +277,9 @@ contract UniswapV2Test is Test, ERC20Permit2Utils {
         inputs[1].token = address(tokenIn1);
         inputs[0].balanceBps = BPS_BASE;
         inputs[1].balanceBps = BPS_BASE;
-        if (inputs[0].balanceBps == SKIP) inputs[0].amountOrOffset = amountIn0;
+        if (inputs[0].balanceBps == BPS_NOT_USED) inputs[0].amountOrOffset = amountIn0;
         else inputs[0].amountOrOffset = 0x40;
-        if (inputs[1].balanceBps == SKIP) inputs[1].amountOrOffset = amountIn1;
+        if (inputs[1].balanceBps == BPS_NOT_USED) inputs[1].amountOrOffset = amountIn1;
         else inputs[1].amountOrOffset = 0x60;
 
         return
@@ -319,7 +319,7 @@ contract UniswapV2Test is Test, ERC20Permit2Utils {
         IParam.Input[] memory inputs = new IParam.Input[](1);
         inputs[0].token = address(tokenIn);
         inputs[0].balanceBps = BPS_BASE;
-        if (inputs[0].balanceBps == SKIP) inputs[0].amountOrOffset = amountIn;
+        if (inputs[0].balanceBps == BPS_NOT_USED) inputs[0].amountOrOffset = amountIn;
         else inputs[0].amountOrOffset = 0x40;
 
         return

--- a/test/integration/UniswapV3.t.sol
+++ b/test/integration/UniswapV3.t.sol
@@ -98,7 +98,7 @@ contract UniswapV3Test is Test, ERC20Permit2Utils, ERC721Utils {
     INonfungiblePositionManager public constant NON_FUNGIBLE_POSITION_MANAGER =
         INonfungiblePositionManager(0xC36442b4a4522E871399CD717aBDD847Ab11FE88);
     uint256 public constant BPS_BASE = 10_000;
-    uint256 public constant SKIP = 0x8000000000000000000000000000000000000000000000000000000000000000;
+    uint256 public constant BPS_NOT_USED = 0;
 
     address public user;
     uint256 public userPrivateKey;
@@ -404,8 +404,8 @@ contract UniswapV3Test is Test, ERC20Permit2Utils, ERC721Utils {
         IParam.Input[] memory inputs = new IParam.Input[](2);
         inputs[0].token = address(token0);
         inputs[1].token = address(token1);
-        inputs[0].balanceBps = SKIP;
-        inputs[1].balanceBps = SKIP;
+        inputs[0].balanceBps = BPS_NOT_USED;
+        inputs[1].balanceBps = BPS_NOT_USED;
         inputs[0].amountOrOffset = amountIn0;
         inputs[1].amountOrOffset = amountIn1;
 
@@ -434,8 +434,8 @@ contract UniswapV3Test is Test, ERC20Permit2Utils, ERC721Utils {
         IParam.Input[] memory inputs = new IParam.Input[](2);
         inputs[0].token = address(token0);
         inputs[1].token = address(token1);
-        inputs[0].balanceBps = SKIP;
-        inputs[1].balanceBps = SKIP;
+        inputs[0].balanceBps = BPS_NOT_USED;
+        inputs[1].balanceBps = BPS_NOT_USED;
         inputs[0].amountOrOffset = amountIn0;
         inputs[1].amountOrOffset = amountIn1;
 

--- a/test/integration/WrappedNative.t.sol
+++ b/test/integration/WrappedNative.t.sol
@@ -15,7 +15,8 @@ contract WrappedNativeTest is Test {
     address public constant NATIVE = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
     IERC20 public constant WRAPPED_NATIVE = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     uint256 public constant BPS_BASE = 10_000;
-    uint256 public constant SKIP = 0x8000000000000000000000000000000000000000000000000000000000000000;
+    uint256 public constant BPS_NOT_USED = 0;
+    uint256 public constant OFFSET_NOT_USED = 0x8000000000000000000000000000000000000000000000000000000000000000;
 
     address public user;
     IRouter public router;
@@ -67,8 +68,8 @@ contract WrappedNativeTest is Test {
         IParam.Input[] memory inputs = new IParam.Input[](1);
         inputs[0].token = NATIVE;
         inputs[0].balanceBps = balanceBps;
-        if (inputs[0].balanceBps == SKIP) inputs[0].amountOrOffset = amountIn;
-        else inputs[0].amountOrOffset = SKIP; // data don't have amount parameter
+        if (inputs[0].balanceBps == BPS_NOT_USED) inputs[0].amountOrOffset = amountIn;
+        else inputs[0].amountOrOffset = OFFSET_NOT_USED; // data don't have amount parameter
 
         return
             IParam.Logic(

--- a/test/integration/YearnV2.t.sol
+++ b/test/integration/YearnV2.t.sol
@@ -21,7 +21,7 @@ contract YearnV2Test is Test, ERC20Permit2Utils {
     IERC20 public constant USDT = IERC20(0xdAC17F958D2ee523a2206206994597C13D831ec7); // USDT
     IYVault public constant yVault = IYVault(0x2f08119C6f07c006695E079AAFc638b8789FAf18); // yUSDT
     uint256 public constant BPS_BASE = 10_000;
-    uint256 public constant SKIP = 0x8000000000000000000000000000000000000000000000000000000000000000;
+    uint256 public constant BPS_NOT_USED = 0;
 
     address public user;
     uint256 public userPrivateKey;
@@ -79,7 +79,7 @@ contract YearnV2Test is Test, ERC20Permit2Utils {
         IParam.Input[] memory inputs = new IParam.Input[](1);
         inputs[0].token = address(tokenIn);
         inputs[0].balanceBps = balanceBps;
-        if (inputs[0].balanceBps == SKIP) inputs[0].amountOrOffset = amountIn;
+        if (inputs[0].balanceBps == BPS_NOT_USED) inputs[0].amountOrOffset = amountIn;
         else inputs[0].amountOrOffset = 0;
 
         return

--- a/test/integration/maker/AgentMakerAction.t.sol
+++ b/test/integration/maker/AgentMakerAction.t.sol
@@ -14,7 +14,7 @@ import {SafeCast160} from 'permit2/libraries/SafeCast160.sol';
 contract AgentMakerActionTest is Test, MakerCommonUtils, ERC20Permit2Utils {
     using SafeCast160 for uint256;
 
-    uint256 public constant SKIP = 0x8000000000000000000000000000000000000000000000000000000000000000;
+    uint256 public constant BPS_NOT_USED = 0;
     address public constant NATIVE = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
     uint256 public constant RAY = 10 ** 27;
     uint256 public constant DRAW_DAI_AMOUNT = 20000 ether;
@@ -388,7 +388,7 @@ contract AgentMakerActionTest is Test, MakerCommonUtils, ERC20Permit2Utils {
         // Encode inputs
         IParam.Input[] memory inputs = new IParam.Input[](1);
         inputs[0].token = NATIVE;
-        inputs[0].balanceBps = SKIP;
+        inputs[0].balanceBps = BPS_NOT_USED;
         inputs[0].amountOrOffset = amount;
 
         return

--- a/test/integration/maker/MakerUtility.t.sol
+++ b/test/integration/maker/MakerUtility.t.sol
@@ -14,7 +14,7 @@ import {SafeCast160} from 'permit2/libraries/SafeCast160.sol';
 contract MakerUtilityTest is Test, MakerCommonUtils, ERC20Permit2Utils {
     using SafeCast160 for uint256;
 
-    uint256 public constant SKIP = 0x8000000000000000000000000000000000000000000000000000000000000000;
+    uint256 public constant BPS_NOT_USED = 0;
     address public constant NATIVE = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
     address public user;
@@ -176,7 +176,7 @@ contract MakerUtilityTest is Test, MakerCommonUtils, ERC20Permit2Utils {
         // Encode inputs
         IParam.Input[] memory inputs = new IParam.Input[](1);
         inputs[0].token = NATIVE;
-        inputs[0].balanceBps = SKIP;
+        inputs[0].balanceBps = BPS_NOT_USED;
         inputs[0].amountOrOffset = value;
 
         return


### PR DESCRIPTION
- Use `0` when basis points calculation is not applied
- Separate `_SKIP` in to `_BPS_NOT_USED` and `_OFFSET_NOT_USED` for better understanding