### PR TITLE
remove unnecessary data in _encodeExecute encodes

### DIFF
--- a/src/fees/AaveFlashLoanFeeCalculator.sol
+++ b/src/fees/AaveFlashLoanFeeCalculator.sol
@@ -55,16 +55,13 @@ contract AaveFlashLoanFeeCalculator is IFeeCalculator, FeeCalculatorBase {
 
         if (params.length > 0) {
             // Decode data in the flash loan
-            (IParam.Logic[] memory logics, IParam.Fee[] memory fees, address[] memory tokensReturn) = abi.decode(
-                params,
-                (IParam.Logic[], IParam.Fee[], address[])
-            );
+            IParam.Logic[] memory logics = abi.decode(params, (IParam.Logic[]));
 
             // Update logics
             logics = Router(router).getLogicsWithFee(logics);
 
             // encode
-            params = abi.encode(logics, fees, tokensReturn);
+            params = abi.encode(logics);
         }
 
         amounts = calculateAmountWithFee(amounts);

--- a/src/fees/BalancerFlashLoanFeeCalculator.sol
+++ b/src/fees/BalancerFlashLoanFeeCalculator.sol
@@ -40,16 +40,13 @@ contract BalancerFlashLoanFeeCalculator is IFeeCalculator, FeeCalculatorBase {
 
         if (userData.length > 0) {
             // Decode data in the flash loan
-            (IParam.Logic[] memory logics, IParam.Fee[] memory fees, address[] memory tokensReturn) = abi.decode(
-                userData,
-                (IParam.Logic[], IParam.Fee[], address[])
-            );
+            IParam.Logic[] memory logics = abi.decode(userData, (IParam.Logic[]));
 
             // Update logics
             logics = Router(router).getLogicsWithFee(logics);
 
             // encode
-            userData = abi.encode(logics, fees, tokensReturn);
+            userData = abi.encode(logics);
         }
 
         amounts = calculateAmountWithFee(amounts);

--- a/test/Agent.t.sol
+++ b/test/Agent.t.sol
@@ -2,8 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {Test} from 'forge-std/Test.sol';
-import {ERC20} from 'openzeppelin-contracts/contracts/token/ERC20/ERC20.sol';
-import {SafeERC20, IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol';
+import {ERC20, IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/ERC20.sol';
 import {Agent} from 'src/Agent.sol';
 import {AgentImplementation, IAgent} from 'src/AgentImplementation.sol';
 import {Router, IRouter} from 'src/Router.sol';
@@ -15,8 +14,6 @@ import {MockFallback} from './mocks/MockFallback.sol';
 import {MockWrappedNative, IWrappedNative} from './mocks/MockWrappedNative.sol';
 
 contract AgentTest is Test {
-    using SafeERC20 for IERC20;
-
     address public constant NATIVE = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
     uint256 public constant BPS_BASE = 10_000;
     uint256 public constant BPS_NOT_USED = 0;

--- a/test/Router.t.sol
+++ b/test/Router.t.sol
@@ -2,16 +2,13 @@
 pragma solidity ^0.8.0;
 
 import {Test} from 'forge-std/Test.sol';
-import {ERC20} from 'openzeppelin-contracts/contracts/token/ERC20/ERC20.sol';
-import {SafeERC20, IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol';
+import {ERC20, IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/ERC20.sol';
 import {Router, IRouter} from 'src/Router.sol';
 import {IParam} from 'src/interfaces/IParam.sol';
 import {MockFallback} from './mocks/MockFallback.sol';
 import {LogicSignature} from './utils/LogicSignature.sol';
 
 contract RouterTest is Test, LogicSignature {
-    using SafeERC20 for IERC20;
-
     address public constant PAUSED = address(0);
     address public constant INIT_CURRENT_USER = address(1);
     uint256 public constant BPS_NOT_USED = 0;

--- a/test/callbacks/AaveV2FlashLoanCallback.t.sol
+++ b/test/callbacks/AaveV2FlashLoanCallback.t.sol
@@ -2,8 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {Test} from 'forge-std/Test.sol';
-import {ERC20} from 'openzeppelin-contracts/contracts/token/ERC20/ERC20.sol';
-import {SafeERC20, IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol';
+import {ERC20, IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/ERC20.sol';
 import {IAgent} from 'src/interfaces/IAgent.sol';
 import {IParam} from 'src/interfaces/IParam.sol';
 import {AaveV2FlashLoanCallback, IAaveV2FlashLoanCallback, IAaveV2Provider} from 'src/callbacks/AaveV2FlashLoanCallback.sol';
@@ -18,8 +17,6 @@ contract AaveV2FlashLoanCallbackTest is Test {
     IERC20 public mockERC20;
 
     // Empty arrays
-    address[] public tokensReturnEmpty;
-    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -79,7 +76,7 @@ contract AaveV2FlashLoanCallbackTest is Test {
         );
 
         // Encode execute data
-        bytes memory params = abi.encode(logics, feesEmpty, tokensReturnEmpty);
+        bytes memory params = abi.encode(logics);
 
         // Execute
         vm.startPrank(aaveV2Provider.getLendingPool());

--- a/test/callbacks/AaveV3FlashLoanCallback.t.sol
+++ b/test/callbacks/AaveV3FlashLoanCallback.t.sol
@@ -2,8 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {Test} from 'forge-std/Test.sol';
-import {ERC20} from 'openzeppelin-contracts/contracts/token/ERC20/ERC20.sol';
-import {SafeERC20, IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol';
+import {ERC20, IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/ERC20.sol';
 import {IAgent} from 'src/interfaces/IAgent.sol';
 import {IParam} from 'src/interfaces/IParam.sol';
 import {AaveV3FlashLoanCallback, IAaveV3FlashLoanCallback, IAaveV3Provider} from 'src/callbacks/AaveV3FlashLoanCallback.sol';
@@ -18,8 +17,6 @@ contract AaveV3FlashLoanCallbackTest is Test {
     IERC20 public mockERC20;
 
     // Empty arrays
-    address[] public tokensReturnEmpty;
-    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -79,7 +76,7 @@ contract AaveV3FlashLoanCallbackTest is Test {
         );
 
         // Encode execute data
-        bytes memory params = abi.encode(logics, feesEmpty, tokensReturnEmpty);
+        bytes memory params = abi.encode(logics);
 
         // Execute
         vm.startPrank(aaveV3Provider.getPool());

--- a/test/callbacks/BalancerV2FlashLoanCallback.t.sol
+++ b/test/callbacks/BalancerV2FlashLoanCallback.t.sol
@@ -2,8 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {Test} from 'forge-std/Test.sol';
-import {ERC20} from 'openzeppelin-contracts/contracts/token/ERC20/ERC20.sol';
-import {SafeERC20, IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol';
+import {ERC20, IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/ERC20.sol';
 import {IAgent} from 'src/interfaces/IAgent.sol';
 import {IParam} from 'src/interfaces/IParam.sol';
 import {BalancerV2FlashLoanCallback, IBalancerV2FlashLoanCallback} from 'src/callbacks/BalancerV2FlashLoanCallback.sol';
@@ -18,8 +17,6 @@ contract BalancerV2FlashLoanCallbackTest is Test {
     IERC20 public mockERC20;
 
     // Empty arrays
-    address[] public tokensReturnEmpty;
-    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -79,7 +76,7 @@ contract BalancerV2FlashLoanCallbackTest is Test {
         );
 
         // Encode execute data
-        bytes memory userData = abi.encode(logics, feesEmpty, tokensReturnEmpty);
+        bytes memory userData = abi.encode(logics);
 
         // Execute
         vm.startPrank(BALANCER_V2_VAULT);

--- a/test/fees/AaveBorrowFeeCalculator.t.sol
+++ b/test/fees/AaveBorrowFeeCalculator.t.sol
@@ -46,10 +46,8 @@ contract AaveBorrowFeeCalculatorTest is Test {
 
     event FeeCharged(address indexed token, uint256 amount, bytes32 metadata);
 
-    address public constant NATIVE = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
     address public constant AAVE_V2_PROVIDER = 0xB53C1a33016B2DC2fF3653530bfF1848a515c8c5;
     address public constant AAVE_V3_PROVIDER = 0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e;
-    address public constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
     address public constant AUSDC_V2 = 0xBcca60bB61934080951369a648Fb03DF4F96263C;
     address public constant AUSDC_V3 = 0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c;
     bytes4 public constant AAVE_BORROW_SELECTOR =
@@ -71,7 +69,6 @@ contract AaveBorrowFeeCalculatorTest is Test {
     address public borrowFeeCalculator;
 
     // Empty arrays
-    address[] public tokensReturnEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -141,14 +138,14 @@ contract AaveBorrowFeeCalculatorTest is Test {
         uint256 newAmount = this.decodeBorrowAmount(logics[0]);
 
         // Execute
-        address[] memory tokensReturns = new address[](1);
-        tokensReturns[0] = collateral;
+        address[] memory tokensReturn = new address[](1);
+        tokensReturn[0] = collateral;
         if (expectedFee > 0) {
             vm.expectEmit(true, true, true, true, address(userAgent));
             emit FeeCharged(collateral, expectedFee, V2_BORROW_META_DATA);
         }
         vm.prank(user);
-        router.execute(logics, tokensReturns, SIGNER_REFERRAL);
+        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
 
         assertEq(IERC20(collateral).balanceOf(address(router)), 0);
         assertEq(IERC20(collateral).balanceOf(address(userAgent)), 0);
@@ -183,14 +180,14 @@ contract AaveBorrowFeeCalculatorTest is Test {
         uint256 newAmount = this.decodeBorrowAmount(logics[0]);
 
         // Execute
-        address[] memory tokensReturns = new address[](1);
-        tokensReturns[0] = collateral;
+        address[] memory tokensReturn = new address[](1);
+        tokensReturn[0] = collateral;
         if (expectedFee > 0) {
             vm.expectEmit(true, true, true, true, address(userAgent));
             emit FeeCharged(collateral, expectedFee, V3_BORROW_META_DATA);
         }
         vm.prank(user);
-        router.execute(logics, tokensReturns, SIGNER_REFERRAL);
+        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
 
         assertEq(IERC20(collateral).balanceOf(address(router)), 0);
         assertEq(IERC20(collateral).balanceOf(address(userAgent)), 0);

--- a/test/fees/AaveFlashLoanFeeCalculator.t.sol
+++ b/test/fees/AaveFlashLoanFeeCalculator.t.sol
@@ -70,7 +70,6 @@ contract AaveFlashLoanFeeCalculatorTest is Test, ERC20Permit2Utils {
 
     // Empty arrays
     address[] public tokensReturnEmpty;
-    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -143,7 +142,7 @@ contract AaveFlashLoanFeeCalculatorTest is Test, ERC20Permit2Utils {
             FeeCalculatorBase(flashLoanFeeCalculator).calculateAmountWithFee(amount),
             isAaveV2
         );
-        bytes memory params = abi.encode(flashLoanLogics, feesEmpty, tokensReturnEmpty);
+        bytes memory params = abi.encode(flashLoanLogics);
 
         // Encode logic
         address[] memory tokens = new address[](1);
@@ -206,7 +205,7 @@ contract AaveFlashLoanFeeCalculatorTest is Test, ERC20Permit2Utils {
                 isAaveV2
             );
             flashLoanLogics[1] = _logicSendNativeToken(user2, nativeAmount);
-            params = abi.encode(flashLoanLogics, feesEmpty, tokensReturnEmpty);
+            params = abi.encode(flashLoanLogics);
         }
 
         IParam.Logic[] memory logics = new IParam.Logic[](1);
@@ -286,7 +285,7 @@ contract AaveFlashLoanFeeCalculatorTest is Test, ERC20Permit2Utils {
             );
             flashLoanLogics[1] = _logicSendNativeToken(user2, nativeAmount);
             flashLoanLogics[2] = logicERC20Permit2PullToken(IERC20(USDT), amount.toUint160());
-            params = abi.encode(flashLoanLogics, feesEmpty, tokensReturnEmpty);
+            params = abi.encode(flashLoanLogics);
         }
 
         // Get new logics and msg.value amount
@@ -331,8 +330,8 @@ contract AaveFlashLoanFeeCalculatorTest is Test, ERC20Permit2Utils {
 
         {
             // Execute
-            address[] memory tokensReturns = new address[](1);
-            tokensReturns[0] = USDT;
+            address[] memory tokensReturn = new address[](1);
+            tokensReturn[0] = USDT;
             if (expectedNativeFee > 0) {
                 vm.expectEmit(true, true, true, true, address(userAgent));
                 emit FeeCharged(NATIVE, expectedNativeFee, NATIVE_TOKEN_META_DATA);
@@ -346,7 +345,7 @@ contract AaveFlashLoanFeeCalculatorTest is Test, ERC20Permit2Utils {
                 emit FeeCharged(USDC, expectedUSDCFee, V2_FLASHLOAN_META_DATA);
             }
             vm.prank(user);
-            router.execute{value: nativeNewAmount}(logics, tokensReturns, SIGNER_REFERRAL);
+            router.execute{value: nativeNewAmount}(logics, tokensReturn, SIGNER_REFERRAL);
         }
 
         assertEq(IERC20(USDC).balanceOf(address(router)), 0);
@@ -375,7 +374,7 @@ contract AaveFlashLoanFeeCalculatorTest is Test, ERC20Permit2Utils {
             FeeCalculatorBase(flashLoanFeeCalculator).calculateAmountWithFee(amount),
             isAaveV2
         );
-        bytes memory params = abi.encode(flashLoanLogics, feesEmpty, tokensReturnEmpty);
+        bytes memory params = abi.encode(flashLoanLogics);
 
         // Encode logic
         address[] memory tokens = new address[](1);

--- a/test/fees/BalancerFlashLoanFeeCalculator.t.sol
+++ b/test/fees/BalancerFlashLoanFeeCalculator.t.sol
@@ -49,7 +49,6 @@ contract BalancerFlashLoanFeeCalculatorTest is Test, ERC20Permit2Utils {
 
     // Empty arrays
     address[] public tokensReturnEmpty;
-    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -113,7 +112,7 @@ contract BalancerFlashLoanFeeCalculatorTest is Test, ERC20Permit2Utils {
             USDC,
             FeeCalculatorBase(flashLoanFeeCalculator).calculateAmountWithFee(amount)
         );
-        bytes memory userData = abi.encode(flashLoanLogics, feesEmpty, tokensReturnEmpty);
+        bytes memory userData = abi.encode(flashLoanLogics);
 
         // Encode logic
         address[] memory tokens = new address[](1);
@@ -172,7 +171,7 @@ contract BalancerFlashLoanFeeCalculatorTest is Test, ERC20Permit2Utils {
             FeeCalculatorBase(flashLoanFeeCalculator).calculateAmountWithFee(amount)
         );
         flashLoanLogics[1] = _logicSendNativeToken(user2, nativeAmount);
-        bytes memory userData = abi.encode(flashLoanLogics, feesEmpty, tokensReturnEmpty);
+        bytes memory userData = abi.encode(flashLoanLogics);
 
         // Get new logics and msg.value amount
         IParam.Logic[] memory logics = new IParam.Logic[](1);
@@ -250,7 +249,7 @@ contract BalancerFlashLoanFeeCalculatorTest is Test, ERC20Permit2Utils {
             );
             flashLoanLogics[1] = _logicSendNativeToken(user2, nativeAmount);
             flashLoanLogics[2] = logicERC20Permit2PullToken(IERC20(USDT), amount.toUint160());
-            userData = abi.encode(flashLoanLogics, feesEmpty, tokensReturnEmpty);
+            userData = abi.encode(flashLoanLogics);
         }
 
         // Get new logics and msg.value amount
@@ -296,8 +295,8 @@ contract BalancerFlashLoanFeeCalculatorTest is Test, ERC20Permit2Utils {
 
         {
             // Execute
-            address[] memory tokensReturns = new address[](1);
-            tokensReturns[0] = USDT;
+            address[] memory tokensReturn = new address[](1);
+            tokensReturn[0] = USDT;
             if (expectedNativeFee > 0) {
                 vm.expectEmit(true, true, true, true, address(userAgent));
                 emit FeeCharged(NATIVE, expectedNativeFee, NATIVE_TOKEN_META_DATA);
@@ -311,7 +310,7 @@ contract BalancerFlashLoanFeeCalculatorTest is Test, ERC20Permit2Utils {
                 emit FeeCharged(USDC, expectedUSDCFee, BALANCER_META_DATA);
             }
             vm.prank(user);
-            router.execute{value: nativeNewAmount}(logics, tokensReturns, SIGNER_REFERRAL);
+            router.execute{value: nativeNewAmount}(logics, tokensReturn, SIGNER_REFERRAL);
         }
 
         assertEq(IERC20(USDC).balanceOf(address(router)), 0);

--- a/test/fees/CompoundV3BorrowFeeCalculator.t.sol
+++ b/test/fees/CompoundV3BorrowFeeCalculator.t.sol
@@ -35,7 +35,6 @@ interface IComet {
 contract CompoundV3BorrowFeeCalculatorTest is Test {
     event FeeCharged(address indexed token, uint256 amount, bytes32 metadata);
 
-    address public constant NATIVE = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
     address public constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
     address public constant C_USDCV3 = 0xc3d688B66703497DAA19211EEdff47f25384cdc3;
     address public constant ANY_TO_ADDRESS = address(0);
@@ -123,14 +122,14 @@ contract CompoundV3BorrowFeeCalculatorTest is Test {
         uint256 newAmount = this.decodeBorrowAmount(logics[0]);
 
         // Execute
-        address[] memory tokensReturns = new address[](1);
-        tokensReturns[0] = baseToken;
+        address[] memory tokensReturn = new address[](1);
+        tokensReturn[0] = baseToken;
         if (expectedFee > 0) {
             vm.expectEmit(true, true, true, true, address(userAgent));
             emit FeeCharged(baseToken, expectedFee, META_DATA);
         }
         vm.prank(user);
-        router.execute(logics, tokensReturns, SIGNER_REFERRAL);
+        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
 
         assertEq(IERC20(baseToken).balanceOf(address(router)), 0);
         assertEq(IERC20(baseToken).balanceOf(address(userAgent)), 0);

--- a/test/fees/FeeGeneralCases.t.sol
+++ b/test/fees/FeeGeneralCases.t.sol
@@ -47,7 +47,6 @@ contract FeeGeneralCasesTest is Test {
 
     // Empty arrays
     address[] public tokensReturnEmpty;
-    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -184,7 +183,7 @@ contract FeeGeneralCasesTest is Test {
             USDC,
             FeeCalculatorBase(flashLoanFeeCalculator).calculateAmountWithFee(amount)
         );
-        bytes memory params = abi.encode(flashLoanLogics, feesEmpty, tokensReturnEmpty);
+        bytes memory params = abi.encode(flashLoanLogics);
 
         // Encode logic
         address[] memory tokens = new address[](1);

--- a/test/fees/MakerDrawFeeCalculator.t.sol
+++ b/test/fees/MakerDrawFeeCalculator.t.sol
@@ -36,7 +36,6 @@ contract MakerDrawFeeCalculatorTest is Test, MakerCommonUtils {
 
     // Empty arrays
     address[] public tokensReturnEmpty;
-    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -72,7 +71,7 @@ contract MakerDrawFeeCalculatorTest is Test, MakerCommonUtils {
         assertEq(IERC20(DAI_TOKEN).balanceOf(user), DRAW_DAI_AMOUNT);
 
         // Build user agent's DSProxy
-        router.execute(_logicBuildDSProxy(), new address[](0), SIGNER_REFERRAL);
+        router.execute(_logicBuildDSProxy(), tokensReturnEmpty, SIGNER_REFERRAL);
         userAgentDSProxy = IDSProxyRegistry(PROXY_REGISTRY).proxies(address(userAgent));
 
         vm.stopPrank();
@@ -151,10 +150,10 @@ contract MakerDrawFeeCalculatorTest is Test, MakerCommonUtils {
         (logics, ) = router.getLogicsAndMsgValueWithFee(logics, 0);
 
         // Execute
-        address[] memory tokensReturns = new address[](1);
-        tokensReturns[0] = address(NATIVE);
+        address[] memory tokensReturn = new address[](1);
+        tokensReturn[0] = address(NATIVE);
         vm.prank(user);
-        router.execute(logics, tokensReturns, SIGNER_REFERRAL);
+        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
 
         assertEq(address(router).balance, 0);
         assertEq(address(userAgent).balance, 0);

--- a/test/fees/Permit2FeeCalculator.t.sol
+++ b/test/fees/Permit2FeeCalculator.t.sol
@@ -30,10 +30,6 @@ contract Permit2FeeCalculatorTest is Test, ERC20Permit2Utils {
     IAgent public userAgent;
     address public permit2FeeCalculator;
 
-    // Empty arrays
-    address[] public tokensReturnEmpty;
-    IParam.Input[] public inputsEmpty;
-
     function setUp() external {
         (user, userPrivateKey) = makeAddrAndKey('User');
         feeCollector = makeAddr('FeeCollector');
@@ -88,14 +84,14 @@ contract Permit2FeeCalculatorTest is Test, ERC20Permit2Utils {
         deal(USDC, user, newAmount);
 
         // Execute
-        address[] memory tokensReturns = new address[](1);
-        tokensReturns[0] = USDC;
+        address[] memory tokensReturn = new address[](1);
+        tokensReturn[0] = USDC;
         if (expectedFee > 0) {
             vm.expectEmit(true, true, true, true, address(userAgent));
             emit FeeCharged(USDC, expectedFee, META_DATA);
         }
         vm.prank(user);
-        router.execute(logics, tokensReturns, SIGNER_REFERRAL);
+        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
 
         assertEq(IERC20(USDC).balanceOf(address(router)), 0);
         assertEq(IERC20(USDC).balanceOf(address(userAgent)), 0);

--- a/test/fees/TransferFromFeeCalculator.t.sol
+++ b/test/fees/TransferFromFeeCalculator.t.sol
@@ -26,7 +26,6 @@ contract TransferFromFeeCalculatorTest is Test {
     address public transferFromFeeCalculator;
 
     // Empty arrays
-    address[] tokensReturnEmpty;
     IParam.Input[] inputsEmpty;
 
     function setUp() external {
@@ -82,14 +81,14 @@ contract TransferFromFeeCalculatorTest is Test {
         deal(USDC, user, newAmount);
 
         // Execute
-        address[] memory tokensReturns = new address[](1);
-        tokensReturns[0] = USDC;
+        address[] memory tokensReturn = new address[](1);
+        tokensReturn[0] = USDC;
         if (expectedFee > 0) {
             vm.expectEmit(true, true, true, true, address(userAgent));
             emit FeeCharged(USDC, expectedFee, META_DATA);
         }
         vm.prank(user);
-        router.execute(logics, tokensReturns, SIGNER_REFERRAL);
+        router.execute(logics, tokensReturn, SIGNER_REFERRAL);
 
         assertEq(IERC20(USDC).balanceOf(address(router)), 0);
         assertEq(IERC20(USDC).balanceOf(address(userAgent)), 0);

--- a/test/integration/AaveV2.t.sol
+++ b/test/integration/AaveV2.t.sol
@@ -63,7 +63,6 @@ contract AaveV2IntegrationTest is Test {
 
     // Empty arrays
     address[] public tokensReturnEmpty;
-    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -220,6 +219,6 @@ contract AaveV2IntegrationTest is Test {
         }
 
         // Encode execute data
-        return abi.encode(logics, feesEmpty, tokensReturnEmpty);
+        return abi.encode(logics);
     }
 }

--- a/test/integration/AaveV3.t.sol
+++ b/test/integration/AaveV3.t.sol
@@ -65,7 +65,6 @@ contract AaveV3IntegrationTest is Test {
 
     // Empty arrays
     address[] public tokensReturnEmpty;
-    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -224,7 +223,7 @@ contract AaveV3IntegrationTest is Test {
         }
 
         // Encode execute data
-        return abi.encode(logics, feesEmpty, tokensReturnEmpty);
+        return abi.encode(logics);
     }
 
     function _percentMul(uint256 value, uint256 percentage) internal pure returns (uint256 result) {

--- a/test/integration/BalancerV2.t.sol
+++ b/test/integration/BalancerV2.t.sol
@@ -30,7 +30,6 @@ contract BalancerV2IntegrationTest is Test {
 
     // Empty arrays
     address[] public tokensReturnEmpty;
-    IParam.Fee[] public feesEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {
@@ -105,6 +104,6 @@ contract BalancerV2IntegrationTest is Test {
         }
 
         // Encode execute data
-        return abi.encode(logics, feesEmpty, tokensReturnEmpty);
+        return abi.encode(logics);
     }
 }

--- a/test/integration/BalancerV2.t.sol
+++ b/test/integration/BalancerV2.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {Test} from 'forge-std/Test.sol';
-import {SafeERC20, IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {Router, IRouter} from 'src/Router.sol';
 import {IAgent} from 'src/interfaces/IAgent.sol';
 import {IParam} from 'src/interfaces/IParam.sol';
@@ -18,8 +18,6 @@ interface IBalancerV2Vault {
 }
 
 contract BalancerV2IntegrationTest is Test {
-    using SafeERC20 for IERC20;
-
     uint256 public constant SIGNER_REFERRAL = 1;
     IBalancerV2Vault public constant balancerV2Vault = IBalancerV2Vault(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
     IERC20 public constant USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);

--- a/test/integration/ERC1155Market.t.sol
+++ b/test/integration/ERC1155Market.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {Test} from 'forge-std/Test.sol';
-import {SafeERC20, IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {IERC1155} from 'openzeppelin-contracts/contracts/token/ERC1155/ERC1155.sol';
 import {SafeCast160} from 'permit2/libraries/SafeCast160.sol';
 import {IAgent} from 'src/interfaces/IAgent.sol';
@@ -13,11 +13,9 @@ import {ERC1155Utils} from '../utils/ERC1155Utils.sol';
 import {MockERC1155Market} from '../mocks/MockERC1155Market.sol';
 
 contract ERC1155MarketTest is Test, ERC20Permit2Utils, ERC1155Utils {
-    using SafeERC20 for IERC20;
     using SafeCast160 for uint256;
 
     IERC20 public constant USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
-    uint256 public constant BPS_BASE = 10_000;
     uint256 public constant BPS_NOT_USED = 0;
 
     address public user;

--- a/test/integration/ERC721Market.t.sol
+++ b/test/integration/ERC721Market.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {Test} from 'forge-std/Test.sol';
-import {SafeERC20, IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {IERC721} from 'openzeppelin-contracts/contracts/token/ERC721/ERC721.sol';
 import {SafeCast160} from 'permit2/libraries/SafeCast160.sol';
 import {IAgent} from 'src/interfaces/IAgent.sol';
@@ -13,11 +13,9 @@ import {ERC721Utils} from '../utils/ERC721Utils.sol';
 import {MockERC721Market} from '../mocks/MockERC721Market.sol';
 
 contract ERC721MarketTest is Test, ERC20Permit2Utils, ERC721Utils {
-    using SafeERC20 for IERC20;
     using SafeCast160 for uint256;
 
     IERC20 public constant USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
-    uint256 public constant BPS_BASE = 10_000;
     uint256 public constant BPS_NOT_USED = 0;
 
     address public user;

--- a/test/integration/UniswapV2.t.sol
+++ b/test/integration/UniswapV2.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {Test} from 'forge-std/Test.sol';
-import {SafeERC20, IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {SafeCast160} from 'permit2/libraries/SafeCast160.sol';
 import {IAgent} from 'src/interfaces/IAgent.sol';
 import {Router, IRouter} from 'src/Router.sol';
@@ -50,7 +50,6 @@ interface IUniswapV2Router02 {
 
 // Test Uniswap whose Router is not ERC20-compliant token
 contract UniswapV2Test is Test, ERC20Permit2Utils {
-    using SafeERC20 for IERC20;
     using SafeCast160 for uint256;
 
     address public constant NATIVE = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
@@ -65,9 +64,6 @@ contract UniswapV2Test is Test, ERC20Permit2Utils {
     uint256 public userPrivateKey;
     IRouter public router;
     IAgent public agent;
-
-    // Empty arrays
-    IParam.Input[] public inputsEmpty;
 
     function setUp() external {
         (user, userPrivateKey) = makeAddrAndKey('User');

--- a/test/integration/UniswapV3.t.sol
+++ b/test/integration/UniswapV3.t.sol
@@ -97,7 +97,6 @@ contract UniswapV3Test is Test, ERC20Permit2Utils, ERC721Utils {
     IERC20 public constant USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
     INonfungiblePositionManager public constant NON_FUNGIBLE_POSITION_MANAGER =
         INonfungiblePositionManager(0xC36442b4a4522E871399CD717aBDD847Ab11FE88);
-    uint256 public constant BPS_BASE = 10_000;
     uint256 public constant BPS_NOT_USED = 0;
 
     address public user;

--- a/test/integration/WrappedNative.t.sol
+++ b/test/integration/WrappedNative.t.sol
@@ -2,15 +2,13 @@
 pragma solidity ^0.8.0;
 
 import {Test} from 'forge-std/Test.sol';
-import {SafeERC20, IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {Router, IRouter} from 'src/Router.sol';
 import {IParam} from 'src/interfaces/IParam.sol';
 import {IWrappedNative} from 'src/interfaces/IWrappedNative.sol';
 
 // Test wrapped native
 contract WrappedNativeTest is Test {
-    using SafeERC20 for IERC20;
-
     uint256 public constant SIGNER_REFERRAL = 1;
     address public constant NATIVE = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
     IERC20 public constant WRAPPED_NATIVE = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);

--- a/test/integration/YearnV2.t.sol
+++ b/test/integration/YearnV2.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {Test} from 'forge-std/Test.sol';
-import {SafeERC20, IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {IAgent} from 'src/interfaces/IAgent.sol';
 import {Router, IRouter} from 'src/Router.sol';
 import {IParam} from 'src/interfaces/IParam.sol';
@@ -16,8 +16,6 @@ interface IYVault {
 
 // Test Yearn V2 which is also an ERC20-compliant token
 contract YearnV2Test is Test, ERC20Permit2Utils {
-    using SafeERC20 for IERC20;
-
     IERC20 public constant USDT = IERC20(0xdAC17F958D2ee523a2206206994597C13D831ec7); // USDT
     IYVault public constant yVault = IYVault(0x2f08119C6f07c006695E079AAFc638b8789FAf18); // yUSDT
     uint256 public constant BPS_BASE = 10_000;
@@ -27,9 +25,6 @@ contract YearnV2Test is Test, ERC20Permit2Utils {
     uint256 public userPrivateKey;
     IRouter public router;
     IAgent public agent;
-
-    // Empty arrays
-    IParam.Input[] public inputsEmpty;
 
     function setUp() external {
         (user, userPrivateKey) = makeAddrAndKey('User');

--- a/test/integration/maker/AgentMakerAction.t.sol
+++ b/test/integration/maker/AgentMakerAction.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {Test} from 'forge-std/Test.sol';
-import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {Router, IRouter} from 'src/Router.sol';
 import {IAgent} from 'src/interfaces/IAgent.sol';
 import {IParam} from 'src/interfaces/IParam.sol';

--- a/test/integration/maker/MakerUtility.t.sol
+++ b/test/integration/maker/MakerUtility.t.sol
@@ -26,7 +26,6 @@ contract MakerUtilityTest is Test, MakerCommonUtils, ERC20Permit2Utils {
     address public makerUtilityDSProxy;
 
     // Empty arrays
-    address[] public tokensReturnEmpty;
     IParam.Input[] public inputsEmpty;
 
     function setUp() external {

--- a/test/invariants/handlers/AgentHandler.sol
+++ b/test/invariants/handlers/AgentHandler.sol
@@ -62,12 +62,7 @@ contract AgentHandler is Test {
             address(0), // approveTo
             address(0) // callback
         );
-        bytes memory data = abi.encodeWithSelector(
-            IAgent.executeByCallback.selector,
-            callbacks,
-            feesEmpty,
-            tokensReturnEmpty
-        );
+        bytes memory data = abi.encodeWithSelector(IAgent.executeByCallback.selector, callbacks);
         IParam.Logic[] memory logics = new IParam.Logic[](1);
         logics[0] = IParam.Logic(
             mCallback,

--- a/test/invariants/handlers/RouterHandler.sol
+++ b/test/invariants/handlers/RouterHandler.sol
@@ -30,7 +30,6 @@ contract RouterHandler is Test, LogicSignature {
     // Empty arrays
     address[] public tokensReturnEmpty;
     IParam.Fee[] public feesEmpty;
-    IParam.Input[] public inputsEmpty;
     IParam.Logic[] public logicsEmpty;
 
     constructor(Router router_) {

--- a/test/mocks/MockERC1155.sol
+++ b/test/mocks/MockERC1155.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
 
 import {ERC1155} from 'openzeppelin-contracts/contracts/token/ERC1155/ERC1155.sol';
-
-pragma solidity ^0.8.0;
 
 contract MockERC1155 is ERC1155 {
     constructor(string memory url) ERC1155(url) {}

--- a/test/mocks/MockERC1155Market.sol
+++ b/test/mocks/MockERC1155Market.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
 
 import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {ERC1155Holder} from 'openzeppelin-contracts/contracts/token/ERC1155/utils/ERC1155Holder.sol';
 import {MockERC1155} from './MockERC1155.sol';
-
-pragma solidity ^0.8.0;
 
 contract MockERC1155Market is ERC1155Holder {
     uint256 public constant amount = 1000000;

--- a/test/mocks/MockERC721.sol
+++ b/test/mocks/MockERC721.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
 
 import {ERC721} from 'openzeppelin-contracts/contracts/token/ERC721/ERC721.sol';
-
-pragma solidity ^0.8.0;
 
 contract MockERC721 is ERC721 {
     constructor(string memory name, string memory symbol) ERC721(name, symbol) {}

--- a/test/mocks/MockERC721Market.sol
+++ b/test/mocks/MockERC721Market.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
 
 import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {ERC721Holder} from 'openzeppelin-contracts/contracts/token/ERC721/utils/ERC721Holder.sol';
 import {MockERC721} from './MockERC721.sol';
-
-pragma solidity ^0.8.0;
 
 contract MockERC721Market is ERC721Holder {
     uint256 public constant amount = 1000000;


### PR DESCRIPTION
- fix flash loan fee Calculator getDataWithFee encode
- fix tokensReturns typo
- remove unnecessary data in _encodeExecute encodes
- remove unnecessary empty arrays
- remove unnecessary constant
- remove unnecessary SafeERC20